### PR TITLE
feat(dashboard): add SLO KPI endpoint for reliability metrics

### DIFF
--- a/server/tests/test_dashboard_slo_api.py
+++ b/server/tests/test_dashboard_slo_api.py
@@ -1,0 +1,48 @@
+import importlib
+
+
+def test_dashboard_slo_api_smoke(monkeypatch):
+    monkeypatch.setenv("DATABASE_URL", "sqlite+pysqlite:///:memory:")
+    monkeypatch.setenv("BOOTSTRAP_USERNAME", "admin")
+    monkeypatch.setenv("BOOTSTRAP_PASSWORD", "admin-password-123")
+    monkeypatch.setenv("UI_COOKIE_SECURE", "false")
+    monkeypatch.setenv("ALLOW_INSECURE_NO_AGENT_TOKEN", "true")
+    monkeypatch.setenv("AGENT_SHARED_TOKEN", "")
+    monkeypatch.setenv("DB_AUTO_CREATE_TABLES", "true")
+    monkeypatch.setenv("DB_REQUIRE_MIGRATIONS_UP_TO_DATE", "false")
+    monkeypatch.setenv("MFA_REQUIRE_FOR_PRIVILEGED", "false")
+
+    app_factory = importlib.import_module("app.app_factory")
+    app = app_factory.create_app()
+
+    from fastapi.testclient import TestClient
+
+    with TestClient(app) as client:
+        # create host for offline ratio metric
+        r = client.post(
+            "/agent/register",
+            json={
+                "agent_id": "srv-001",
+                "hostname": "srv-001",
+                "os_id": "ubuntu",
+                "os_version": "22.04",
+                "kernel": "test",
+                "labels": {"env": "test"},
+            },
+        )
+        assert r.status_code == 200, r.text
+
+        # login to access dashboard API
+        r = client.post("/auth/login", json={"username": "admin", "password": "admin-password-123"})
+        assert r.status_code == 200, r.text
+
+        slo = client.get("/dashboard/slo", params={"hours": 24})
+        assert slo.status_code == 200, slo.text
+        data = slo.json()
+
+        assert data["window_hours"] == 24
+        assert "kpis" in data
+        assert "job_success_rate" in data["kpis"]
+        assert "median_patch_duration" in data["kpis"]
+        assert "auth_error_rate" in data["kpis"]
+        assert "offline_host_ratio" in data["kpis"]


### PR DESCRIPTION
## Summary
Adds backend SLO KPI endpoint for core reliability indicators.

Closes #10

## What changed
- Added `GET /dashboard/slo?hours=<n>` endpoint.
- Returns KPI set for current window (+ previous window baseline where applicable):
  - `job_success_rate` (percent from completed job runs)
  - `median_patch_duration` (seconds from pkg/dist upgrade runs)
  - `auth_error_rate` (percent from OIDC auth events)
  - `offline_host_ratio` (percent currently offline hosts)

## Testing
- Added `server/tests/test_dashboard_slo_api.py`
- Verified:
  - `cd server && ./.venv/bin/pytest -q tests/test_dashboard_slo_api.py tests/test_jobs_flow.py`
  - `cd server && ./.venv/bin/pytest -q tests`

## Notes
- This provides the API backbone; dashboard UI cards can consume this in a follow-up PR.
