### PR TITLE
feat: scheduled backup verification policy + alerts (#21)

### DIFF
--- a/server/alembic/versions/20260225_01_backup_verification_policy.py
+++ b/server/alembic/versions/20260225_01_backup_verification_policy.py
@@ -1,0 +1,54 @@
+"""add backup verification policy table
+
+Revision ID: 20260225_01
+Revises: 20260225_00
+Create Date: 2026-02-25
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+revision = "20260225_01"
+down_revision = "20260225_00"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "backup_verification_policy",
+        sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("enabled", sa.Boolean(), nullable=False, server_default=sa.true()),
+        sa.Column("backup_path", sa.String(), nullable=False),
+        sa.Column("expected_sha256", sa.String(), nullable=True),
+        sa.Column("expected_schema_version", sa.Integer(), nullable=True),
+        sa.Column("schedule_kind", sa.String(), nullable=False, server_default="daily"),
+        sa.Column("timezone", sa.String(), nullable=False, server_default="UTC"),
+        sa.Column("time_hhmm", sa.String(), nullable=False, server_default="03:00"),
+        sa.Column("weekday", sa.Integer(), nullable=True),
+        sa.Column("stale_after_hours", sa.Integer(), nullable=False, server_default="36"),
+        sa.Column("alert_on_failure", sa.Boolean(), nullable=False, server_default=sa.true()),
+        sa.Column("alert_on_stale", sa.Boolean(), nullable=False, server_default=sa.true()),
+        sa.Column("next_run_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("last_run_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("last_status", sa.String(), nullable=True),
+        sa.Column("last_error", sa.String(), nullable=True),
+        sa.Column("last_alert_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.text("now()")),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.text("now()")),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index("ix_backup_verification_policy_next_run_at", "backup_verification_policy", ["next_run_at"], unique=False)
+    op.create_index("ix_backup_verification_policy_last_run_at", "backup_verification_policy", ["last_run_at"], unique=False)
+    op.create_index("ix_backup_verification_policy_last_alert_at", "backup_verification_policy", ["last_alert_at"], unique=False)
+    op.create_index("ix_backup_verification_policy_created_at", "backup_verification_policy", ["created_at"], unique=False)
+
+
+def downgrade() -> None:
+    op.drop_index("ix_backup_verification_policy_created_at", table_name="backup_verification_policy")
+    op.drop_index("ix_backup_verification_policy_last_alert_at", table_name="backup_verification_policy")
+    op.drop_index("ix_backup_verification_policy_last_run_at", table_name="backup_verification_policy")
+    op.drop_index("ix_backup_verification_policy_next_run_at", table_name="backup_verification_policy")
+    op.drop_table("backup_verification_policy")

--- a/server/app/models.py
+++ b/server/app/models.py
@@ -521,3 +521,32 @@ class BackupVerificationRun(Base):
     started_at = Column(DateTime(timezone=True), nullable=False, index=True)
     finished_at = Column(DateTime(timezone=True), nullable=False, index=True)
     created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False, index=True)
+
+
+class BackupVerificationPolicy(Base):
+    __tablename__ = "backup_verification_policy"
+
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    enabled = Column(Boolean, nullable=False, default=True)
+
+    backup_path = Column(String, nullable=False)
+    expected_sha256 = Column(String)
+    expected_schema_version = Column(Integer)
+
+    schedule_kind = Column(String, nullable=False, default="daily")  # daily|weekly
+    timezone = Column(String, nullable=False, default="UTC")
+    time_hhmm = Column(String, nullable=False, default="03:00")
+    weekday = Column(Integer)
+
+    stale_after_hours = Column(Integer, nullable=False, default=36)
+    alert_on_failure = Column(Boolean, nullable=False, default=True)
+    alert_on_stale = Column(Boolean, nullable=False, default=True)
+
+    next_run_at = Column(DateTime(timezone=True), index=True)
+    last_run_at = Column(DateTime(timezone=True), index=True)
+    last_status = Column(String)
+    last_error = Column(String)
+    last_alert_at = Column(DateTime(timezone=True), index=True)
+
+    created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False, index=True)
+    updated_at = Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=False)

--- a/server/app/routers/dashboard.py
+++ b/server/app/routers/dashboard.py
@@ -787,7 +787,13 @@ def dashboard_notifications(db: Session = Depends(get_db), user=Depends(require_
             latest_ts = latest_verified.finished_at if latest_verified else None
             if latest_ts is not None and latest_ts.tzinfo is None:
                 latest_ts = latest_ts.replace(tzinfo=timezone.utc)
-            if latest_ts is None or latest_ts < stale_cutoff:
+
+            stale = latest_ts is None or latest_ts < stale_cutoff
+            if latest_verify is not None and latest_verify.status != "verified":
+                # If the latest run is not verified, keep stale signal active as well.
+                stale = True
+
+            if stale:
                 candidates.append({
                     "id": f"backup-verify-stale:{int(stale_cutoff.timestamp())}",
                     "dedupe_key": "backup_verification:stale",

--- a/server/app/routers/dashboard.py
+++ b/server/app/routers/dashboard.py
@@ -779,6 +779,8 @@ def dashboard_notifications(db: Session = Depends(get_db), user=Depends(require_
         if policy.alert_on_stale and policy.stale_after_hours:
             stale_cutoff = now - timedelta(hours=int(policy.stale_after_hours))
             latest_ts = latest_verify.finished_at if latest_verify else None
+            if latest_ts is not None and latest_ts.tzinfo is None:
+                latest_ts = latest_ts.replace(tzinfo=timezone.utc)
             if latest_ts is None or latest_ts < stale_cutoff:
                 candidates.append({
                     "id": f"backup-verify-stale:{int(stale_cutoff.timestamp())}",

--- a/server/app/services/backup_verification.py
+++ b/server/app/services/backup_verification.py
@@ -1,0 +1,151 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import shutil
+import sqlite3
+import tarfile
+import tempfile
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+
+from sqlalchemy.orm import Session
+
+from ..models import BackupVerificationRun
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as f:
+        while True:
+            chunk = f.read(1024 * 1024)
+            if not chunk:
+                break
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def detect_sqlite_file(path: Path) -> Path | None:
+    if path.suffix.lower() in {".sqlite", ".db", ".sqlite3"}:
+        return path
+    return None
+
+
+def rehearse_restore(path: Path, expected_schema_version: int | None) -> tuple[bool, bool, int | None, str]:
+    """Restore rehearsal + version compatibility check.
+
+    Returns: restore_ok, compatibility_ok, schema_version, detail
+    """
+    sqlite_candidate = detect_sqlite_file(path)
+
+    with tempfile.TemporaryDirectory(prefix="lcm-backup-verify-") as tmp:
+        tmpdir = Path(tmp)
+
+        if tarfile.is_tarfile(path):
+            with tarfile.open(path, "r:*") as tf:
+                tf.extractall(tmpdir)
+            for ext in ("*.sqlite", "*.db", "*.sqlite3"):
+                found = list(tmpdir.rglob(ext))
+                if found:
+                    sqlite_candidate = found[0]
+                    break
+
+        if sqlite_candidate is None or not sqlite_candidate.exists():
+            return True, True, None, "No sqlite payload found; extraction rehearsal succeeded"
+
+        rehearse_copy = tmpdir / "rehearsal.sqlite"
+        shutil.copy2(sqlite_candidate, rehearse_copy)
+
+        conn = sqlite3.connect(str(rehearse_copy))
+        try:
+            cur = conn.cursor()
+            row = cur.execute("PRAGMA integrity_check;").fetchone()
+            if not row or str(row[0]).lower() != "ok":
+                return False, False, None, f"SQLite integrity_check failed: {row}"
+            schema_row = cur.execute("PRAGMA user_version;").fetchone()
+            schema_version = int(schema_row[0] if schema_row else 0)
+        finally:
+            conn.close()
+
+        compatibility_ok = True
+        if expected_schema_version is not None and schema_version < expected_schema_version:
+            compatibility_ok = False
+
+        return True, compatibility_ok, schema_version, "SQLite restore rehearsal passed"
+
+
+def run_and_persist_backup_verification(
+    db: Session,
+    *,
+    backup_path: str,
+    expected_sha256: str | None,
+    expected_schema_version: int | None,
+    created_by: str | None,
+) -> BackupVerificationRun:
+    started_at = datetime.now(timezone.utc)
+
+    bpath = Path(backup_path).expanduser().resolve()
+    checksum_actual = sha256_file(bpath)
+    checksum_expected = (expected_sha256 or "").strip().lower() or None
+    integrity_ok = bool((checksum_expected is None) or (checksum_actual.lower() == checksum_expected))
+
+    restore_ok, compatibility_ok, schema_version, detail = rehearse_restore(
+        bpath,
+        expected_schema_version,
+    )
+
+    status = "verified" if (integrity_ok and restore_ok and compatibility_ok) else "failed"
+    finished_at = datetime.now(timezone.utc)
+
+    report = {
+        "run_id": None,
+        "status": status,
+        "backup_path": str(bpath),
+        "integrity": {
+            "ok": integrity_ok,
+            "algorithm": "sha256",
+            "actual": checksum_actual,
+            "expected": checksum_expected,
+        },
+        "restore_rehearsal": {
+            "ok": restore_ok,
+            "detail": detail,
+        },
+        "compatibility": {
+            "ok": compatibility_ok,
+            "schema_version": schema_version,
+            "expected_schema_version": expected_schema_version,
+        },
+        "started_at": started_at.isoformat(),
+        "finished_at": finished_at.isoformat(),
+    }
+
+    report_dir = Path("/tmp/lcm-backup-verification-reports")
+    report_dir.mkdir(parents=True, exist_ok=True)
+    run_id = uuid.uuid4()
+    report["run_id"] = str(run_id)
+    artifact_path = report_dir / f"{run_id}.json"
+    artifact_path.write_text(json.dumps(report, indent=2), encoding="utf-8")
+
+    row = BackupVerificationRun(
+        id=run_id,
+        status=status,
+        backup_path=str(bpath),
+        checksum_algorithm="sha256",
+        checksum_actual=checksum_actual,
+        checksum_expected=checksum_expected,
+        integrity_ok=integrity_ok,
+        restore_ok=restore_ok,
+        compatibility_ok=compatibility_ok,
+        schema_version=schema_version,
+        expected_schema_version=expected_schema_version,
+        artifact_path=str(artifact_path),
+        detail={"restore_detail": detail},
+        started_at=started_at,
+        finished_at=finished_at,
+        created_by=created_by,
+    )
+    db.add(row)
+    db.flush()
+    return row

--- a/server/app/services/backup_verification_policy.py
+++ b/server/app/services/backup_verification_policy.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+import logging
+from datetime import datetime, time, timedelta, timezone
+from zoneinfo import ZoneInfo
+
+from sqlalchemy import desc, select
+from sqlalchemy.orm import Session
+
+from ..config import settings
+from ..db import SessionLocal
+from ..models import AuditEvent, BackupVerificationPolicy, BackupVerificationRun
+from .backup_verification import run_and_persist_backup_verification
+from .db_utils import transaction
+from .teams import post_teams_message
+
+logger = logging.getLogger(__name__)
+
+
+def _parse_hhmm(hhmm: str | None, default: time = time(3, 0)) -> time:
+    raw = (hhmm or "").strip()
+    if ":" not in raw:
+        return default
+    try:
+        h, m = raw.split(":", 1)
+        return time(hour=max(0, min(23, int(h))), minute=max(0, min(59, int(m))))
+    except Exception:
+        return default
+
+
+def _next_run(now_utc: datetime, policy: BackupVerificationPolicy) -> datetime:
+    tz_name = (policy.timezone or "UTC").strip() or "UTC"
+    try:
+        tz = ZoneInfo(tz_name)
+    except Exception:
+        tz = timezone.utc
+
+    now_local = now_utc.astimezone(tz)
+    tod = _parse_hhmm(policy.time_hhmm)
+
+    if (policy.schedule_kind or "daily") == "weekly":
+        target_wd = int(policy.weekday if policy.weekday is not None else 0)
+        target_wd = max(0, min(6, target_wd))
+        delta = (target_wd - now_local.weekday()) % 7
+        cand = datetime(now_local.year, now_local.month, now_local.day, tod.hour, tod.minute, tzinfo=tz) + timedelta(days=delta)
+        if cand <= now_local:
+            cand = cand + timedelta(days=7)
+        return cand.astimezone(timezone.utc)
+
+    cand = datetime(now_local.year, now_local.month, now_local.day, tod.hour, tod.minute, tzinfo=tz)
+    if cand <= now_local:
+        cand = cand + timedelta(days=1)
+    return cand.astimezone(timezone.utc)
+
+
+def run_policy_tick_once(db: Session) -> None:
+    now = datetime.now(timezone.utc)
+    policy = db.execute(select(BackupVerificationPolicy).order_by(BackupVerificationPolicy.created_at.asc()).limit(1)).scalar_one_or_none()
+    if not policy or not policy.enabled:
+        return
+    if not policy.next_run_at or policy.next_run_at > now:
+        return
+
+    with transaction(db):
+        p = db.execute(select(BackupVerificationPolicy).where(BackupVerificationPolicy.id == policy.id)).scalar_one()
+        if not p.enabled or not p.next_run_at or p.next_run_at > now:
+            return
+        # advance first to avoid duplicate dispatch
+        p.next_run_at = _next_run(now, p)
+
+    run_status = "failed"
+    run_id = None
+    err = None
+    try:
+        with transaction(db):
+            row = run_and_persist_backup_verification(
+                db,
+                backup_path=p.backup_path,
+                expected_sha256=p.expected_sha256,
+                expected_schema_version=p.expected_schema_version,
+                created_by="cron",
+            )
+            run_status = row.status
+            run_id = str(row.id)
+            p2 = db.execute(select(BackupVerificationPolicy).where(BackupVerificationPolicy.id == p.id)).scalar_one()
+            p2.last_run_at = row.finished_at
+            p2.last_status = row.status
+            p2.last_error = None if row.status == "verified" else "verification failed"
+            db.add(
+                AuditEvent(
+                    action="backup_verification.run",
+                    actor_username="cron",
+                    actor_role="system",
+                    target_type="backup_verification_run",
+                    target_id=str(row.id),
+                    meta={"status": row.status, "trigger": "policy_schedule"},
+                    created_at=now,
+                )
+            )
+    except Exception as e:
+        err = str(e)
+        logger.exception("backup verification policy run failed")
+        with transaction(db):
+            p2 = db.execute(select(BackupVerificationPolicy).where(BackupVerificationPolicy.id == p.id)).scalar_one()
+            p2.last_run_at = now
+            p2.last_status = "failed"
+            p2.last_error = err[:1000]
+
+    # Alerts: failure and stale
+    latest = db.execute(select(BackupVerificationRun).order_by(desc(BackupVerificationRun.finished_at)).limit(1)).scalar_one_or_none()
+    stale = False
+    if latest and latest.finished_at and p.stale_after_hours:
+        stale_cutoff = now - timedelta(hours=int(p.stale_after_hours))
+        stale = latest.finished_at < stale_cutoff
+
+    should_alert_failure = bool(p.alert_on_failure and (run_status == "failed"))
+    should_alert_stale = bool(p.alert_on_stale and stale)
+
+    if should_alert_failure or should_alert_stale:
+        webhook = (getattr(settings, "teams_webhook_url", None) or "").strip()
+        if bool(getattr(settings, "teams_alerts_enabled", False)) and webhook:
+            lines = [f"Policy: scheduled backup verification", f"Run status: {run_status}"]
+            if run_id:
+                lines.append(f"Run id: {run_id}")
+            if err:
+                lines.append(f"Error: {err[:300]}")
+            if should_alert_stale:
+                lines.append(f"Latest verification is stale (> {int(p.stale_after_hours)}h)")
+            try:
+                post_teams_message(webhook, "Backup verification alert", lines)
+                with transaction(db):
+                    p3 = db.execute(select(BackupVerificationPolicy).where(BackupVerificationPolicy.id == p.id)).scalar_one()
+                    p3.last_alert_at = now
+            except Exception:
+                logger.exception("backup verification Teams alert failed")
+
+
+def run_policy_tick_once_fresh_session() -> None:
+    with SessionLocal() as db:
+        run_policy_tick_once(db)

--- a/server/app/services/cronjobs.py
+++ b/server/app/services/cronjobs.py
@@ -12,6 +12,7 @@ from sqlalchemy.orm import Session
 
 from ..db import SessionLocal
 from ..models import CronJob, CronJobRun
+from .backup_verification_policy import run_policy_tick_once
 from .db_utils import transaction
 from .jobs import create_job_with_runs, push_job_to_agents
 
@@ -33,6 +34,9 @@ async def _run_tick() -> None:
     now = datetime.now(timezone.utc)
 
     with SessionLocal() as db:
+        # Backup verification policy scheduler piggybacks on cron tick loop.
+        run_policy_tick_once(db)
+
         # Find due scheduled jobs
         due = (
             db.execute(

--- a/server/tests/test_backup_verification_policy_api.py
+++ b/server/tests/test_backup_verification_policy_api.py
@@ -1,0 +1,77 @@
+import importlib
+import sqlite3
+from datetime import datetime, timedelta, timezone
+
+
+def _boot_app(monkeypatch):
+    monkeypatch.setenv("DATABASE_URL", "sqlite+pysqlite:///:memory:")
+    monkeypatch.setenv("BOOTSTRAP_USERNAME", "admin")
+    monkeypatch.setenv("BOOTSTRAP_PASSWORD", "admin-password-123")
+    monkeypatch.setenv("UI_COOKIE_SECURE", "false")
+    monkeypatch.setenv("ALLOW_INSECURE_NO_AGENT_TOKEN", "true")
+    monkeypatch.setenv("AGENT_SHARED_TOKEN", "")
+    monkeypatch.setenv("DB_AUTO_CREATE_TABLES", "true")
+    monkeypatch.setenv("DB_REQUIRE_MIGRATIONS_UP_TO_DATE", "false")
+    monkeypatch.setenv("MFA_REQUIRE_FOR_PRIVILEGED", "false")
+
+    app_factory = importlib.import_module("app.app_factory")
+    return app_factory.create_app()
+
+
+def test_backup_verification_policy_run_now_and_notifications(monkeypatch, tmp_path):
+    app = _boot_app(monkeypatch)
+
+    db_path = tmp_path / "backup.sqlite"
+    conn = sqlite3.connect(str(db_path))
+    cur = conn.cursor()
+    cur.execute("PRAGMA user_version=2;")
+    cur.execute("CREATE TABLE sample(id INTEGER PRIMARY KEY, name TEXT);")
+    conn.commit()
+    conn.close()
+
+    from fastapi.testclient import TestClient
+
+    with TestClient(app) as client:
+        r = client.post("/auth/login", json={"username": "admin", "password": "admin-password-123"})
+        assert r.status_code == 200, r.text
+        csrf = client.cookies.get("fleet_csrf")
+        headers = {"X-CSRF-Token": csrf} if csrf else {}
+
+        put = client.put(
+            "/backup-verification/policy",
+            json={
+                "enabled": True,
+                "backup_path": str(db_path),
+                "expected_schema_version": 1,
+                "schedule_kind": "daily",
+                "timezone": "UTC",
+                "time_hhmm": "03:00",
+                "stale_after_hours": 1,
+                "alert_on_failure": True,
+                "alert_on_stale": True,
+            },
+            headers=headers,
+        )
+        assert put.status_code == 200, put.text
+
+        run = client.post("/backup-verification/policy/run-now", headers=headers)
+        assert run.status_code == 200, run.text
+        d = run.json()
+        assert d["status"] == "verified"
+
+        # Force stale condition via DB and ensure dashboard notifications include backup verification alert.
+        from app.db import SessionLocal
+        from app.models import BackupVerificationPolicy, BackupVerificationRun
+
+        with SessionLocal() as db:
+            p = db.query(BackupVerificationPolicy).first()
+            rr = db.query(BackupVerificationRun).order_by(BackupVerificationRun.finished_at.desc()).first()
+            rr.finished_at = datetime.now(timezone.utc) - timedelta(hours=2)
+            p.stale_after_hours = 1
+            db.commit()
+
+        n = client.get("/dashboard/notifications")
+        assert n.status_code == 200, n.text
+        items = n.json().get("items") or []
+        kinds = {it.get("kind") for it in items}
+        assert "backup_verification_stale" in kinds


### PR DESCRIPTION
## Summary
Implements issue #21 as a tight vertical slice on top of the backup verification primitives from #19/#20.

### What's included
- Adds `backup_verification_policy` persistence model + Alembic migration.
- Adds policy API endpoints:
  - `GET /backup-verification/policy`
  - `PUT /backup-verification/policy`
  - `POST /backup-verification/policy/run-now`
- Refactors verification execution into reusable service (`services/backup_verification.py`).
- Scheduled policy runner (`services/backup_verification_policy.py`) integrated into cron tick loop.
- Alerts vertical slice:
  - dashboard notifications now emit `backup_verification_failed` and `backup_verification_stale` candidates
  - optional Teams webhook alerting when enabled
- Audit behavior:
  - logs `backup_verification.run` for manual/scheduled policy runs
  - logs `backup_verification.policy.updated` on policy changes
- Tests:
  - `test_backup_verification_policy_api.py` for policy run-now + stale notification behavior

## Notes
- Scope intentionally focused and safe: daily/weekly scheduling, run-now, stale/failure alerts.
- Uses the existing verification run primitives instead of introducing a second verification path.

Closes #21
