### PR TITLE
feat(ui): wire rollout controls to pause/resume/approve APIs

### DIFF
--- a/server/alembic/versions/20260225_02_patch_campaign_rollout_meta.py
+++ b/server/alembic/versions/20260225_02_patch_campaign_rollout_meta.py
@@ -1,0 +1,27 @@
+"""patch campaigns rollout meta
+
+Revision ID: 20260225_02
+Revises: 20260225_01
+Create Date: 2026-02-25
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "20260225_02"
+down_revision = "20260225_01"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "patch_campaigns",
+        sa.Column("rollout_meta", sa.JSON(), nullable=False, server_default=sa.text("'{}'")),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("patch_campaigns", "rollout_meta")

--- a/server/app/models.py
+++ b/server/app/models.py
@@ -253,6 +253,9 @@ class PatchCampaign(Base):
     reboot_if_needed = Column(Boolean, nullable=False, default=False)
     include_kernel = Column(Boolean, nullable=False, default=False)
 
+    # Rollout controls/state (wave progression, pause/resume, auto-pause threshold)
+    rollout_meta = Column(JSON, nullable=False, default=dict)
+
     status = Column(String, nullable=False, default="scheduled", index=True)  # scheduled|running|success|failed|canceled
 
     created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False, index=True)

--- a/server/app/templates/index.html
+++ b/server/app/templates/index.html
@@ -281,6 +281,22 @@
               </div>
             </div>
 
+            <div class="admin-card" id="rollout-controls-card" style="margin-top:1rem;">
+              <div class="admin-card-title" style="display:flex;align-items:center;justify-content:space-between;gap:1rem;flex-wrap:wrap;">
+                <span>Rollout controls</span>
+                <div style="display:flex;gap:0.5rem;flex-wrap:wrap;align-items:center;">
+                  <input id="rollout-campaign-id" class="host-search" type="text" placeholder="campaign id (pc-...)" style="width:220px;max-width:100%;" />
+                  <button class="btn" id="rollout-load" type="button">Load</button>
+                  <button class="btn" id="rollout-pause" type="button">Pause</button>
+                  <button class="btn" id="rollout-resume" type="button">Resume</button>
+                  <button class="btn btn-primary" id="rollout-approve-next" type="button">Approve next wave</button>
+                </div>
+              </div>
+              <div class="admin-card-body">
+                <div id="rollout-summary" class="status-muted">Paste a campaign id and click Load.</div>
+                <div id="rollout-status" class="status-muted" style="margin-top:0.45rem;"></div>
+              </div>
+            </div>
 
             <div class="admin-card" id="notifications-card" style="margin-top:1rem;">
               <div class="admin-card-title" style="display:flex;align-items:center;justify-content:space-between;gap:1rem;flex-wrap:wrap;">

--- a/server/tests/frontend/phase3-rollout-controls.test.js
+++ b/server/tests/frontend/phase3-rollout-controls.test.js
@@ -1,0 +1,136 @@
+import { describe, it, expect, vi } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import vm from 'node:vm';
+
+function loadBrowserScript(filePath, baseWindow = {}) {
+  const code = fs.readFileSync(filePath, 'utf8');
+  const windowObj = {
+    ...baseWindow,
+    window: null,
+    document: baseWindow.document || {},
+    console: baseWindow.console || console,
+    setTimeout,
+    clearTimeout,
+    setInterval,
+    clearInterval,
+  };
+  windowObj.window = windowObj;
+  const context = vm.createContext(windowObj);
+  vm.runInContext(code, context, { filename: filePath });
+  return context;
+}
+
+function makeEl(extra = {}) {
+  const handlers = {};
+  return {
+    textContent: '',
+    innerHTML: '',
+    value: '',
+    style: {},
+    dataset: {},
+    disabled: false,
+    classList: { add() {}, remove() {}, contains() { return false; } },
+    addEventListener(type, cb) { handlers[type] = cb; },
+    dispatch(type, evt = {}) { if (handlers[type]) handlers[type](evt); },
+    ...extra,
+  };
+}
+
+describe('phase3 rollout controls wiring', () => {
+  const root = path.resolve(path.dirname(new URL(import.meta.url).pathname), '../../..');
+  const overviewPath = path.join(root, 'server/app/templates/fleet-phase3-overview.js');
+
+  it('loads rollout summary from campaign id input', async () => {
+    const els = {
+      'nav-overview': makeEl(),
+      'nav-hosts': makeEl(),
+      'nav-cronjobs': makeEl(),
+      'nav-sshkeys': makeEl(),
+      'overview-next-cronjobs-open': makeEl(),
+      'overview-refresh': makeEl(),
+      'kpi-timeframe': makeEl({ value: '24' }),
+      'overview-inventory-now': makeEl(),
+      'overview-security-campaign': makeEl(),
+      'overview-dist-upgrade': makeEl(),
+      'failed-runs-refresh': makeEl(),
+      'notifications-refresh': makeEl(),
+      'teams-test-alert': makeEl(),
+      'teams-send-brief': makeEl(),
+      'report-refresh': makeEl(),
+      'report-sort': makeEl(),
+      'report-order': makeEl(),
+      'rollout-campaign-id': makeEl({ value: 'pc-123' }),
+      'rollout-load': makeEl(),
+      'rollout-pause': makeEl(),
+      'rollout-resume': makeEl(),
+      'rollout-approve-next': makeEl(),
+      'rollout-summary': makeEl(),
+      'rollout-status': makeEl(),
+      'server-info-tab': makeEl({ classList: { add() {}, remove() {}, contains() { return true; } } }),
+      'hosts-table-tab': makeEl({ classList: { add() {}, remove() {}, contains() { return false; } } }),
+      'cronjobs-tab': makeEl({ classList: { add() {}, remove() {}, contains() { return false; } } }),
+      'sshkeys-tab': makeEl({ classList: { add() {}, remove() {}, contains() { return false; } } }),
+    };
+
+    const fetchMock = vi.fn(async (url) => {
+      if (String(url).includes('/patching/campaigns/pc-123/rollout')) {
+        return {
+          ok: true,
+          text: async () => JSON.stringify({
+            campaign_id: 'pc-123',
+            status: 'running',
+            hosts_done: 2,
+            hosts_total: 4,
+            hosts_failed: 1,
+            rollout: { paused: false, approved_through_ring: 0 },
+            waves: [{ name: 'canary', size: 1, failed: 0 }],
+          }),
+        };
+      }
+      return { ok: true, json: async () => ({ items: [] }), text: async () => '{}' };
+    });
+
+    const win = loadBrowserScript(overviewPath, {
+      document: {
+        getElementById: (id) => els[id] || null,
+        querySelectorAll: () => [],
+        querySelector: () => ({ classList: { add() {}, remove() {} } }),
+      },
+      fetch: fetchMock,
+      escapeHtml: (s) => String(s),
+      setTableState: () => {},
+      updateReportSortIndicators: () => {},
+      updateHostsSortIndicators: () => {},
+      bindSortableHeader: () => {},
+      setupReportSortHandlers: () => {},
+      setupKpiHandlers: () => {},
+      wireBusyClick: (el, _label, fn) => { if (el) el.addEventListener('click', (e) => fn(e)); },
+      showToast: () => {},
+      loadNotifications: () => {},
+      refreshMaintenanceGuardButtons: () => {},
+    });
+
+    const ctx = {
+      clearCurrentHostSelection: () => {},
+      loadFleetOverview: async () => {},
+      loadPendingUpdatesReport: async () => {},
+      loadHosts: async () => {},
+      loadFailedRuns: async () => {},
+      loadHostsTable: async () => {},
+      loadCronjobs: async () => {},
+      loadSshKeys: async () => {},
+      loadSshKeyRequests: async () => {},
+      maybeLoadSshKeyAdminQueue: async () => {},
+      loadAdminSshKeys: async () => {},
+      getLastRenderedAgentIds: () => [],
+      formatShortTime: () => 'now',
+    };
+
+    win.phase3Overview.initFleetOverviewControls(ctx);
+
+    await els['rollout-load'].dispatch('click', { preventDefault() {} });
+
+    expect(fetchMock).toHaveBeenCalledWith('/patching/campaigns/pc-123/rollout', { credentials: 'include' });
+  });
+});

--- a/server/tests/test_patching_rollout_controls_api.py
+++ b/server/tests/test_patching_rollout_controls_api.py
@@ -1,0 +1,139 @@
+import asyncio
+import importlib
+import sys
+
+
+def _reload_app_modules():
+    for k in list(sys.modules.keys()):
+        if k == "app" or k.startswith("app."):
+            sys.modules.pop(k, None)
+
+
+def _bootstrap_app(monkeypatch):
+    monkeypatch.setenv("DATABASE_URL", "sqlite+pysqlite:///:memory:")
+    monkeypatch.setenv("BOOTSTRAP_USERNAME", "admin")
+    monkeypatch.setenv("BOOTSTRAP_PASSWORD", "admin-password-123")
+    monkeypatch.setenv("MFA_REQUIRE_FOR_PRIVILEGED", "false")
+    monkeypatch.setenv("ALLOW_INSECURE_NO_AGENT_TOKEN", "true")
+    monkeypatch.setenv("DB_AUTO_CREATE_TABLES", "true")
+    monkeypatch.setenv("DB_REQUIRE_MIGRATIONS_UP_TO_DATE", "false")
+    _reload_app_modules()
+    app_factory = importlib.import_module("app.app_factory")
+    return app_factory.create_app()
+
+
+def _register_host(client, agent_id: str, labels: dict | None = None):
+    r = client.post(
+        "/agent/register",
+        json={
+            "agent_id": agent_id,
+            "hostname": agent_id,
+            "fqdn": None,
+            "os_id": "ubuntu",
+            "os_version": "24.04",
+            "kernel": "test",
+            "labels": labels or {},
+        },
+    )
+    assert r.status_code == 200, r.text
+
+
+def _auth_headers(client) -> dict:
+    lr = client.post("/auth/login", json={"username": "admin", "password": "admin-password-123"})
+    assert lr.status_code == 200, lr.text
+    csrf = client.cookies.get("fleet_csrf")
+    return {"X-CSRF-Token": csrf} if csrf else {}
+
+
+def _campaign_payload():
+    return {
+        "agent_ids": ["srv-001", "srv-002", "srv-003"],
+        "rings": [
+            {"name": "canary", "agent_ids": ["srv-001"]},
+            {"name": "batch-1", "agent_ids": ["srv-002", "srv-003"]},
+        ],
+        "window_start": "2026-02-25T00:00:00Z",
+        "window_end": "2026-02-26T00:00:00Z",
+        "concurrency": 2,
+        "rollout_controls": {
+            "progressive": True,
+            "auto_pause_enabled": True,
+            "failure_threshold_percent": 50,
+        },
+    }
+
+
+def test_rollout_pause_resume_and_approve_next(monkeypatch):
+    app = _bootstrap_app(monkeypatch)
+    from fastapi.testclient import TestClient
+
+    with TestClient(app) as client:
+        for aid in ["srv-001", "srv-002", "srv-003"]:
+            _register_host(client, aid, labels={"env": "prod"})
+        headers = _auth_headers(client)
+
+        cr = client.post("/patching/campaigns/security-updates", json=_campaign_payload(), headers=headers)
+        assert cr.status_code == 200, cr.text
+        cid = cr.json()["campaign_id"]
+
+        rr = client.get(f"/patching/campaigns/{cid}/rollout", headers=headers)
+        assert rr.status_code == 200, rr.text
+        data = rr.json()
+        assert data["rollout"]["progressive"] is True
+        assert data["rollout"]["approved_through_ring"] == 0
+
+        an = client.post(f"/patching/campaigns/{cid}/approve-next", headers=headers)
+        assert an.status_code == 200, an.text
+        assert an.json()["rollout"]["approved_through_ring"] == 1
+
+        pz = client.post(f"/patching/campaigns/{cid}/pause?reason=manual", headers=headers)
+        assert pz.status_code == 200, pz.text
+        assert pz.json()["rollout"]["paused"] is True
+
+        rs = client.post(f"/patching/campaigns/{cid}/resume", headers=headers)
+        assert rs.status_code == 200, rs.text
+        assert rs.json()["rollout"]["paused"] is False
+
+
+def test_auto_pause_on_failure_threshold(monkeypatch):
+    app = _bootstrap_app(monkeypatch)
+    from fastapi.testclient import TestClient
+
+    with TestClient(app) as client:
+        for aid in ["srv-001", "srv-002", "srv-003"]:
+            _register_host(client, aid, labels={"env": "prod"})
+        headers = _auth_headers(client)
+
+        cr = client.post("/patching/campaigns/security-updates", json=_campaign_payload(), headers=headers)
+        assert cr.status_code == 200, cr.text
+        cid = cr.json()["campaign_id"]
+
+        models = importlib.import_module("app.models")
+        db_mod = importlib.import_module("app.db")
+        patching_svc = importlib.import_module("app.services.patching")
+
+        db = db_mod.SessionLocal()
+        try:
+            c = db.query(models.PatchCampaign).filter(models.PatchCampaign.campaign_key == cid).one()
+            hosts = (
+                db.query(models.PatchCampaignHost)
+                .filter(models.PatchCampaignHost.campaign_id == c.id)
+                .all()
+            )
+            # Force canary ring to completed with 50% failure rate.
+            for h in hosts:
+                if h.ring == 0:
+                    h.status = "failed" if h.agent_id == "srv-001" else "success"
+                else:
+                    h.status = "queued"
+            db.commit()
+
+            asyncio.run(patching_svc._advance_campaign(db, c))
+            db.commit()
+            db.refresh(c)
+            meta = c.rollout_meta or {}
+            assert bool(meta.get("paused")) is True
+            assert "failure threshold" in str(meta.get("pause_reason") or "").lower()
+            assert meta.get("paused_by") == "system"
+        finally:
+            db.close()


### PR DESCRIPTION
## Summary\n- add an Overview rollout control panel with campaign ID input\n- wire UI actions for load, pause, resume, and approve-next-wave to the rollout APIs introduced in #36\n- auto-fill campaign ID after creating a security campaign and load rollout snapshot immediately\n- add frontend regression test that verifies rollout summary endpoint wiring\n\n## Testing\n- npm run test:frontend\n\nCloses #15