### PR TITLE
Make hosts kernel column size dynamically

### DIFF
--- a/server/app/templates/fleet-ui.css
+++ b/server/app/templates/fleet-ui.css
@@ -1900,11 +1900,10 @@ body.fleet-report {
   white-space: nowrap;
 }
 
-/* 1080p: make Hosts table fit without horizontal scroll */
+/* Hosts table: let columns size naturally to their content */
 .hosts-table {
   width: 100%;
-  table-layout: fixed;
-  /* enables predictable column sizing */
+  table-layout: auto;
 }
 
 /* Slightly tighter table to save width, use percentage/flex where possible */
@@ -1940,11 +1939,11 @@ body.fleet-report {
   min-width: 100px;
 }
 
-/* Kernel: flexible */
+/* Kernel: size to actual kernel string instead of reserving a large fixed slice */
 .hosts-table th:nth-child(4),
 .hosts-table td:nth-child(4) {
-  width: 20%;
-  min-width: 140px;
+  width: 1%;
+  min-width: 0;
   font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
 }
 

--- a/server/tests/frontend/hosts-table-layout.test.js
+++ b/server/tests/frontend/hosts-table-layout.test.js
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+describe('hosts table layout CSS', () => {
+  const root = path.resolve(path.dirname(new URL(import.meta.url).pathname), '../../..');
+  const cssPath = path.join(root, 'server/app/templates/fleet-ui.css');
+  const src = fs.readFileSync(cssPath, 'utf8');
+
+  it('uses auto table layout for the hosts table so columns can size naturally', () => {
+    expect(src).toContain('.hosts-table {\n  width: 100%;\n  table-layout: auto;\n}');
+    expect(src).not.toContain('.hosts-table {\n  width: 100%;\n  table-layout: fixed;');
+  });
+
+  it('does not reserve a fixed 20 percent width for the Kernel column', () => {
+    const marker = '.hosts-table th:nth-child(4),\n.hosts-table td:nth-child(4) {';
+    const start = src.indexOf(marker);
+    expect(start).toBeGreaterThanOrEqual(0);
+    const section = src.slice(start, start + 220);
+
+    expect(section).toContain('width: 1%;');
+    expect(section).toContain('min-width: 0;');
+    expect(section).not.toContain('width: 20%;');
+    expect(section).not.toContain('min-width: 140px;');
+  });
+});


### PR DESCRIPTION
## Summary
- switch the Hosts table back to auto layout for natural column sizing
- stop reserving a large fixed width for the Kernel column
- add a frontend regression test for the Hosts table layout

## Test Plan
- npm run test:frontend -- hosts-table-layout.test.js host-actions-menu.test.js
