### PR TITLE
Fix admin user refresh and owner-tag host visibility

### DIFF
--- a/server/app/services/user_scopes.py
+++ b/server/app/services/user_scopes.py
@@ -57,20 +57,24 @@ def user_has_scope_limits(db: Session, user: AppUser) -> bool:
 def is_host_visible_to_user(db: Session, user: AppUser, host: Host) -> bool:
     if is_admin(user):
         return True
-    selectors = get_user_scope_selectors(db, user)
-    if not selectors:
-        return True
 
     labels = (getattr(host, "labels", None) or {}) if host is not None else {}
-    for sel in selectors:
-        ok = True
-        for k, allowed in sel.items():
-            if str(labels.get(k, "")).strip() not in allowed:
-                ok = False
-                break
-        if ok:
-            return True
-    return False
+    selectors = get_user_scope_selectors(db, user)
+    if selectors:
+        for sel in selectors:
+            ok = True
+            for k, allowed in sel.items():
+                if str(labels.get(k, "")).strip() not in allowed:
+                    ok = False
+                    break
+            if ok:
+                return True
+        return False
+
+    username = str(getattr(user, "username", "") or "").strip()
+    if not username:
+        return False
+    return str(labels.get("owner", "")).strip() == username
 
 
 def filter_agent_ids_for_user(db: Session, user: AppUser, agent_ids: list[str]) -> list[str]:

--- a/server/app/templates/fleet-phase3-auth-ui.js
+++ b/server/app/templates/fleet-phase3-auth-ui.js
@@ -39,6 +39,12 @@ function initAdminPanel() {
           setAdminStatus(`User ${createdUser} created.`, 'success');
           showToast(`User ${createdUser} created.`, 'success');
           passwordInput.value = '';
+          if (typeof window.loadAdminUsers === 'function') {
+            try { await window.loadAdminUsers(); } catch (_) { }
+          }
+          if (typeof window.loadAdminAudit === 'function') {
+            try { await window.loadAdminAudit(); } catch (_) { }
+          }
         } catch (e) {
           const msg = e.message || String(e);
           setAdminStatus(msg, 'error');

--- a/server/tests/frontend/admin-create-user-refresh.test.js
+++ b/server/tests/frontend/admin-create-user-refresh.test.js
@@ -1,0 +1,16 @@
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+describe('admin create-user refresh behavior', () => {
+  const root = path.resolve(path.dirname(new URL(import.meta.url).pathname), '../../..');
+  const filePath = path.join(root, 'server/app/templates/fleet-phase3-auth-ui.js');
+  const src = fs.readFileSync(filePath, 'utf8');
+
+  it('refreshes admin users and audit after successful user creation', () => {
+    expect(src).toContain("if (typeof window.loadAdminUsers === 'function')");
+    expect(src).toContain('await window.loadAdminUsers()');
+    expect(src).toContain("if (typeof window.loadAdminAudit === 'function')");
+    expect(src).toContain('await window.loadAdminAudit()');
+  });
+});

--- a/server/tests/test_owner_tag_visibility.py
+++ b/server/tests/test_owner_tag_visibility.py
@@ -1,0 +1,16 @@
+from types import SimpleNamespace
+
+from app.services import user_scopes
+
+
+def test_non_admin_without_explicit_scopes_only_sees_matching_owner_tag(monkeypatch):
+    monkeypatch.setattr(user_scopes, 'get_user_scope_selectors', lambda db, user: [])
+
+    user = SimpleNamespace(username='imre', role='operator', id='u1')
+    owned_host = SimpleNamespace(labels={'owner': 'imre'})
+    foreign_host = SimpleNamespace(labels={'owner': 'alice'})
+    unlabeled_host = SimpleNamespace(labels={})
+
+    assert user_scopes.is_host_visible_to_user(None, user, owned_host) is True
+    assert user_scopes.is_host_visible_to_user(None, user, foreign_host) is False
+    assert user_scopes.is_host_visible_to_user(None, user, unlabeled_host) is False

--- a/server/tests/test_owner_tag_visibility.py
+++ b/server/tests/test_owner_tag_visibility.py
@@ -1,9 +1,9 @@
 from types import SimpleNamespace
 
-from app.services import user_scopes
-
 
 def test_non_admin_without_explicit_scopes_only_sees_matching_owner_tag(monkeypatch):
+    from app.services import user_scopes
+
     monkeypatch.setattr(user_scopes, 'get_user_scope_selectors', lambda db, user: [])
 
     user = SimpleNamespace(username='imre', role='operator', id='u1')


### PR DESCRIPTION
## Summary
- refresh the Admin Users list immediately after successful user creation
- refresh admin audit after successful user creation
- restrict non-admin users without explicit scope rows to hosts where labels.owner matches their username
- add focused frontend and backend regression tests for both behaviors

## Test Plan
- npm run test:frontend -- admin-create-user-refresh.test.js
- ./server/.venv/bin/pytest -q server/tests/test_owner_tag_visibility.py

## Notes
- focused tests passed locally
- broader backend suite in this local environment still has unrelated existing failures tied to local Postgres/path assumptions, so this PR is intentionally verified with targeted regression coverage
