### PR TITLE
Fix owner visibility and drift 404s for regular users

### DIFF
--- a/server/app/routers/hosts.py
+++ b/server/app/routers/hosts.py
@@ -77,6 +77,7 @@ def update_host_metadata(
 
     next_hostname = _clean_optional_str(payload.hostname, field="hostname")
     next_role = _clean_optional_str(payload.role, field="role")
+    next_owner = _clean_optional_str(payload.owner, field="owner")
 
     next_env: dict[str, str] | None = None
     if payload.env is not None:
@@ -98,6 +99,8 @@ def update_host_metadata(
         host.hostname = next_hostname
     if next_role is not None:
         labels["role"] = next_role
+    if next_owner is not None:
+        labels["owner"] = next_owner
     if next_env is not None:
         # Replace env_vars with what UI sends (supports true deletes from UI row removal).
         labels["env_vars"] = dict(next_env)

--- a/server/app/routers/reports.py
+++ b/server/app/routers/reports.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from datetime import datetime, timezone
+from types import SimpleNamespace
 
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy import case, func, select
@@ -10,6 +11,7 @@ from ..config import settings
 from ..db import get_db
 from ..deps import require_ui_user
 from ..models import Host, HostPackageUpdate
+from ..services.user_scopes import is_host_visible_to_user
 
 router = APIRouter(prefix="/reports", tags=["reports"])
 
@@ -120,9 +122,13 @@ def hosts_updates_report(
     col = sort_col_map[sort]
     q = q.order_by(col.asc() if order == "asc" else col.desc())
 
-    total = db.execute(select(func.count()).select_from(q.subquery())).scalar_one()
-
-    rows = db.execute(q.limit(limit).offset(offset)).all()
+    all_rows = db.execute(q).all()
+    visible_rows = [
+        r for r in all_rows
+        if is_host_visible_to_user(db, user, SimpleNamespace(labels=r.labels or {}))
+    ]
+    total = len(visible_rows)
+    rows = visible_rows[offset:offset + limit]
 
     items = []
     for r in rows:

--- a/server/app/schemas.py
+++ b/server/app/schemas.py
@@ -81,4 +81,5 @@ class JobCreateCVECheck(BaseModel):
 class HostMetadataUpdate(BaseModel):
     hostname: Optional[str] = None
     role: Optional[str] = None
+    owner: Optional[str] = None
     env: Optional[Dict[str, str]] = None

--- a/server/app/templates/fleet-phase3-host-list.js
+++ b/server/app/templates/fleet-phase3-host-list.js
@@ -162,6 +162,10 @@
       const hosts = await response.json();
       const list = Array.isArray(hosts) ? hosts : [];
       ctx.setAllHosts(list);
+      const currentAgentId = (typeof ctx.getCurrentAgentId === 'function') ? (ctx.getCurrentAgentId() || '') : '';
+      if (currentAgentId && !list.some((h) => String(h?.agent_id || '') === String(currentAgentId))) {
+        if (typeof ctx.clearCurrentHostSelection === 'function') ctx.clearCurrentHostSelection();
+      }
       rebuildLabelFilterOptions(ctx);
 
       if (list.length === 0) {

--- a/server/app/templates/fleet-phase3-overview.js
+++ b/server/app/templates/fleet-phase3-overview.js
@@ -712,6 +712,10 @@
       const d = await r.json();
       const items = d?.items || [];
       hostsTableItemsCache = Array.isArray(items) ? items : [];
+      const currentAgentId = (ctx && typeof ctx.getCurrentAgentId === 'function') ? (ctx.getCurrentAgentId() || '') : '';
+      if (currentAgentId && !hostsTableItemsCache.some((it) => String(it?.agent_id || '') === String(currentAgentId))) {
+        if (ctx && typeof ctx.clearCurrentHostSelection === 'function') ctx.clearCurrentHostSelection();
+      }
       if (sort === 'owner') {
         const dir = order === 'desc' ? -1 : 1;
         hostsTableItemsCache.sort((a, b) => {

--- a/server/tests/frontend/regular-user-owner-visibility.test.js
+++ b/server/tests/frontend/regular-user-owner-visibility.test.js
@@ -1,0 +1,21 @@
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+describe('regular-user owner visibility guards', () => {
+  const root = path.resolve(path.dirname(new URL(import.meta.url).pathname), '../../..');
+  const hostListPath = path.join(root, 'server/app/templates/fleet-phase3-host-list.js');
+  const overviewPath = path.join(root, 'server/app/templates/fleet-phase3-overview.js');
+  const hostListSrc = fs.readFileSync(hostListPath, 'utf8');
+  const overviewSrc = fs.readFileSync(overviewPath, 'utf8');
+
+  it('clears stale current host selection when the sidebar host list no longer contains it', () => {
+    expect(hostListSrc).toContain("if (currentAgentId && !list.some((h) => String(h?.agent_id || '') === String(currentAgentId))) {");
+    expect(hostListSrc).toContain("if (typeof ctx.clearCurrentHostSelection === 'function') ctx.clearCurrentHostSelection();");
+  });
+
+  it('clears stale current host selection when the hosts table result set no longer contains it', () => {
+    expect(overviewSrc).toContain("if (currentAgentId && !hostsTableItemsCache.some((it) => String(it?.agent_id || '') === String(currentAgentId))) {");
+    expect(overviewSrc).toContain("if (ctx && typeof ctx.clearCurrentHostSelection === 'function') ctx.clearCurrentHostSelection();");
+  });
+});

--- a/server/tests/test_host_metadata_update_api.py
+++ b/server/tests/test_host_metadata_update_api.py
@@ -26,7 +26,7 @@ def _seed_host(agent_id="agent-1", hostname="old-host", labels=None):
 
 
 def _login(client):
-    r = client.post("/auth/login", json={"username": "admin", "password": "admin-...-123"})
+    r = client.post("/auth/login", json={"username": "admin", "password": "admin-password-123"})
     assert r.status_code == 200, r.text
     csrf = client.cookies.get("fleet_csrf")
     return {"X-CSRF-Token": csrf} if csrf else {}
@@ -98,22 +98,3 @@ def test_update_host_metadata_env_key_sets_legacy_env_and_clears_on_remove(monke
         clear_labels = clear_resp.json()["host"]["labels"]
         assert clear_labels["env_vars"] == {}
         assert "env" not in clear_labels
-
-
-def test_update_host_metadata_owner_persists_owner_label(monkeypatch):
-    app = _boot_app(monkeypatch)
-    _seed_host(agent_id="agent-owner", labels={"team": "ops"})
-
-    from fastapi.testclient import TestClient
-
-    with TestClient(app) as client:
-        headers = _login(client)
-        resp = client.patch(
-            "/hosts/agent-owner/metadata",
-            json={"owner": "imre"},
-            headers=headers,
-        )
-        assert resp.status_code == 200, resp.text
-        labels = resp.json()["host"]["labels"]
-        assert labels["owner"] == "imre"
-        assert labels["team"] == "ops"

--- a/server/tests/test_host_metadata_update_api.py
+++ b/server/tests/test_host_metadata_update_api.py
@@ -26,7 +26,7 @@ def _seed_host(agent_id="agent-1", hostname="old-host", labels=None):
 
 
 def _login(client):
-    r = client.post("/auth/login", json={"username": "admin", "password": "admin-password-123"})
+    r = client.post("/auth/login", json={"username": "admin", "password": "admin-...-123"})
     assert r.status_code == 200, r.text
     csrf = client.cookies.get("fleet_csrf")
     return {"X-CSRF-Token": csrf} if csrf else {}
@@ -98,3 +98,22 @@ def test_update_host_metadata_env_key_sets_legacy_env_and_clears_on_remove(monke
         clear_labels = clear_resp.json()["host"]["labels"]
         assert clear_labels["env_vars"] == {}
         assert "env" not in clear_labels
+
+
+def test_update_host_metadata_owner_persists_owner_label(monkeypatch):
+    app = _boot_app(monkeypatch)
+    _seed_host(agent_id="agent-owner", labels={"team": "ops"})
+
+    from fastapi.testclient import TestClient
+
+    with TestClient(app) as client:
+        headers = _login(client)
+        resp = client.patch(
+            "/hosts/agent-owner/metadata",
+            json={"owner": "imre"},
+            headers=headers,
+        )
+        assert resp.status_code == 200, resp.text
+        labels = resp.json()["host"]["labels"]
+        assert labels["owner"] == "imre"
+        assert labels["team"] == "ops"

--- a/server/tests/test_reports_owner_visibility.py
+++ b/server/tests/test_reports_owner_visibility.py
@@ -1,0 +1,57 @@
+from types import SimpleNamespace
+
+from app.routers import reports
+
+
+class _Result:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def all(self):
+        return list(self._rows)
+
+
+class _DB:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def execute(self, _query):
+        return _Result(self._rows)
+
+
+def test_hosts_updates_report_filters_rows_by_owner_visibility(monkeypatch):
+    rows = [
+        SimpleNamespace(
+            agent_id='a1', hostname='owned', fqdn=None, ip_address=None,
+            os_id='ubuntu', os_version='24.04', kernel='k1',
+            labels={'owner': 'imre'}, last_seen=None, reboot_required=False,
+            updates=1, security_updates=1,
+        ),
+        SimpleNamespace(
+            agent_id='a2', hostname='foreign', fqdn=None, ip_address=None,
+            os_id='ubuntu', os_version='24.04', kernel='k2',
+            labels={'owner': 'alice'}, last_seen=None, reboot_required=False,
+            updates=2, security_updates=0,
+        ),
+    ]
+
+    monkeypatch.setattr(
+        reports,
+        'is_host_visible_to_user',
+        lambda db, user, host: str((host.labels or {}).get('owner', '')).strip() == 'imre',
+    )
+
+    out = reports.hosts_updates_report(
+        only_pending=False,
+        online_only=False,
+        sort='hostname',
+        order='asc',
+        limit=500,
+        offset=0,
+        db=_DB(rows),
+        user=SimpleNamespace(username='imre', role='operator'),
+    )
+
+    assert out['total'] == 1
+    assert len(out['items']) == 1
+    assert out['items'][0]['agent_id'] == 'a1'

--- a/server/tests/test_reports_owner_visibility.py
+++ b/server/tests/test_reports_owner_visibility.py
@@ -1,7 +1,5 @@
 from types import SimpleNamespace
 
-from app.routers import reports
-
 
 class _Result:
     def __init__(self, rows):
@@ -20,6 +18,8 @@ class _DB:
 
 
 def test_hosts_updates_report_filters_rows_by_owner_visibility(monkeypatch):
+    from app.routers import reports
+
     rows = [
         SimpleNamespace(
             agent_id='a1', hostname='owned', fqdn=None, ip_address=None,


### PR DESCRIPTION
## Summary
- persist host owner metadata via the host metadata API
- apply user visibility filtering to the hosts updates report used by the Hosts table
- clear stale selected hosts when the newly visible host set no longer contains them
- add focused regressions for report visibility and stale selection clearing

## Test Plan
- npm run test:frontend -- regular-user-owner-visibility.test.js admin-create-user-refresh.test.js
- ./server/.venv/bin/pytest -q server/tests/test_owner_tag_visibility.py server/tests/test_reports_owner_visibility.py

## Notes
- focused regressions pass locally
- test_host_metadata_update_api.py was extended with an owner metadata case, but that file is environment-sensitive in this local session because of pre-existing local DB import timing issues
