### PR TITLE
Enforce owner-only host visibility for regular users

### DIFF
--- a/server/app/routers/auth.py
+++ b/server/app/routers/auth.py
@@ -1157,13 +1157,12 @@ def auth_admin_rbac_explain(
 
     matched_selector = None
     selector_results: list[dict] = []
+    host_owner = str(labels.get("owner", "") or "").strip()
+    target_username = str(getattr(target, "username", "") or "").strip()
 
     if role == "admin":
         allowed = True
         reason = "admin role grants host visibility"
-    elif not selectors:
-        allowed = True
-        reason = "no scope limits configured for user"
     else:
         for sel in selectors:
             misses = []
@@ -1180,14 +1179,13 @@ def auth_admin_rbac_explain(
             if matched and matched_selector is None:
                 matched_selector = _sanitize_selector(sel)
 
-        allowed = bool(matched_selector is not None)
-        reason = "matched at least one selector" if allowed else "no selector matched host labels"
-
-    # Double-check with canonical helper to prevent drift.
-    helper_allowed = is_host_visible_to_user(db, target, host)
-    if helper_allowed != allowed:
-        allowed = helper_allowed
-        reason = f"helper override: {reason}"
+        allowed = bool(host_owner) and host_owner == target_username
+        if not host_owner:
+            reason = "host has no owner label; non-admin visibility is denied"
+        elif host_owner != target_username:
+            reason = "host owner does not match username"
+        else:
+            reason = "host owner matches username"
 
     out = {
         "allowed": allowed,

--- a/server/app/services/user_scopes.py
+++ b/server/app/services/user_scopes.py
@@ -59,32 +59,23 @@ def is_host_visible_to_user(db: Session, user: AppUser, host: Host) -> bool:
         return True
 
     labels = (getattr(host, "labels", None) or {}) if host is not None else {}
-    selectors = get_user_scope_selectors(db, user)
-    if selectors:
-        for sel in selectors:
-            ok = True
-            for k, allowed in sel.items():
-                if str(labels.get(k, "")).strip() not in allowed:
-                    ok = False
-                    break
-            if ok:
-                return True
-        return False
-
     username = str(getattr(user, "username", "") or "").strip()
     if not username:
         return False
-    return str(labels.get("owner", "")).strip() == username
+
+    owner = str(labels.get("owner", "") or "").strip()
+    if not owner:
+        return False
+    return owner == username
 
 
 def filter_agent_ids_for_user(db: Session, user: AppUser, agent_ids: list[str]) -> list[str]:
     if is_admin(user):
         return sorted(list(set([a for a in agent_ids if a])))
 
-    selectors = get_user_scope_selectors(db, user)
     uniq = sorted(list(set([a for a in agent_ids if a])))
-    if not selectors:
-        return uniq
+    if not uniq:
+        return []
 
     hosts = db.execute(select(Host).where(Host.agent_id.in_(uniq))).scalars().all()
     host_by_agent = {h.agent_id: h for h in hosts}

--- a/server/tests/test_owner_tag_visibility.py
+++ b/server/tests/test_owner_tag_visibility.py
@@ -1,7 +1,7 @@
 from types import SimpleNamespace
 
 
-def test_non_admin_without_explicit_scopes_only_sees_matching_owner_tag(monkeypatch):
+def test_non_admin_host_visibility_requires_matching_owner_tag(monkeypatch):
     from app.services import user_scopes
 
     monkeypatch.setattr(user_scopes, 'get_user_scope_selectors', lambda db, user: [])
@@ -14,3 +14,16 @@ def test_non_admin_without_explicit_scopes_only_sees_matching_owner_tag(monkeypa
     assert user_scopes.is_host_visible_to_user(None, user, owned_host) is True
     assert user_scopes.is_host_visible_to_user(None, user, foreign_host) is False
     assert user_scopes.is_host_visible_to_user(None, user, unlabeled_host) is False
+
+
+def test_non_admin_scope_selectors_do_not_override_owner_visibility(monkeypatch):
+    from app.services import user_scopes
+
+    monkeypatch.setattr(user_scopes, 'get_user_scope_selectors', lambda db, user: [{'env': ['prod']}])
+
+    user = SimpleNamespace(username='imre', role='operator', id='u1')
+    foreign_but_scoped = SimpleNamespace(labels={'owner': 'alice', 'env': 'prod'})
+    owned_even_without_scope_match = SimpleNamespace(labels={'owner': 'imre', 'env': 'dev'})
+
+    assert user_scopes.is_host_visible_to_user(None, user, foreign_but_scoped) is False
+    assert user_scopes.is_host_visible_to_user(None, user, owned_even_without_scope_match) is True

--- a/server/tests/test_rbac_explain_api.py
+++ b/server/tests/test_rbac_explain_api.py
@@ -33,6 +33,7 @@ def test_admin_rbac_explain_allow_and_deny(monkeypatch):
                 "labels": {
                     "env": "prod",
                     "team": "core",
+                    "owner": "op1",
                     "secret_token": "VERY_SECRET_TOKEN_" + ("x" * 120),
                 },
             },
@@ -62,7 +63,7 @@ def test_admin_rbac_explain_allow_and_deny(monkeypatch):
         reg = client.post("/auth/register", json={"username": "op1", "password": "pw-123456"}, headers=headers)
         assert reg.status_code == 200, reg.text
 
-        # set scoped selector env=prod
+        # set a legacy selector too; owner-based visibility should still be decisive
         set_scope = client.post(
             "/auth/admin/users/op1/scopes",
             json={"selectors": [{"env": ["prod"]}]},


### PR DESCRIPTION
## Summary
- enforce owner-only host visibility for non-admin users in the canonical visibility helper
- prevent old scope-selector logic from bypassing owner-tag access control
- add focused backend regression coverage for owner-only visibility semantics

## Test Plan
- ./server/.venv/bin/pytest -q server/tests/test_owner_tag_visibility.py server/tests/test_reports_owner_visibility.py
- npm run test:frontend -- regular-user-owner-visibility.test.js
