### PR TITLE
Clear owner label when host owner is removed

### DIFF
--- a/server/app/routers/hosts.py
+++ b/server/app/routers/hosts.py
@@ -75,9 +75,12 @@ def update_host_metadata(
     if not host or not is_host_visible_to_user(db, user, host):
         raise HTTPException(404, "Host not found")
 
+    provided_fields = set(getattr(payload, "model_fields_set", getattr(payload, "__fields_set__", set())) or set())
+
     next_hostname = _clean_optional_str(payload.hostname, field="hostname")
     next_role = _clean_optional_str(payload.role, field="role")
     next_owner = _clean_optional_str(payload.owner, field="owner")
+    owner_provided = "owner" in provided_fields
 
     next_env: dict[str, str] | None = None
     if payload.env is not None:
@@ -99,8 +102,11 @@ def update_host_metadata(
         host.hostname = next_hostname
     if next_role is not None:
         labels["role"] = next_role
-    if next_owner is not None:
-        labels["owner"] = next_owner
+    if owner_provided:
+        if next_owner:
+            labels["owner"] = next_owner
+        else:
+            labels.pop("owner", None)
     if next_env is not None:
         # Replace env_vars with what UI sends (supports true deletes from UI row removal).
         labels["env_vars"] = dict(next_env)

--- a/server/tests/test_host_owner_clear_api_logic.py
+++ b/server/tests/test_host_owner_clear_api_logic.py
@@ -1,0 +1,78 @@
+from types import SimpleNamespace
+
+
+def test_update_host_metadata_clears_owner_when_owner_field_is_present_and_empty(monkeypatch):
+    from app.routers import hosts as hosts_router
+    from app.schemas import HostMetadataUpdate
+
+    host = SimpleNamespace(agent_id='agent-1', hostname='srv-1', labels={'owner': 'imre', 'team': 'ops'})
+
+    class _Result:
+        def __init__(self, host_obj):
+            self._host = host_obj
+
+        def scalar_one_or_none(self):
+            return self._host
+
+    class _DB:
+        def __init__(self, host_obj):
+            self._host = host_obj
+            self.committed = False
+
+        def execute(self, _query):
+            return _Result(self._host)
+
+        def commit(self):
+            self.committed = True
+
+    monkeypatch.setattr(hosts_router, 'permissions_for', lambda user: {'can_manage_users': True})
+    monkeypatch.setattr(hosts_router, 'is_host_visible_to_user', lambda db, user, host_obj: True)
+
+    payload = HostMetadataUpdate(owner='')
+    db = _DB(host)
+    user = SimpleNamespace(username='admin')
+
+    out = hosts_router.update_host_metadata('agent-1', payload, db=db, user=user)
+
+    assert db.committed is True
+    assert 'owner' not in host.labels
+    assert host.labels['team'] == 'ops'
+    assert 'owner' not in out['host']['labels']
+
+
+def test_update_host_metadata_sets_owner_when_non_empty_owner_is_provided(monkeypatch):
+    from app.routers import hosts as hosts_router
+    from app.schemas import HostMetadataUpdate
+
+    host = SimpleNamespace(agent_id='agent-1', hostname='srv-1', labels={'team': 'ops'})
+
+    class _Result:
+        def __init__(self, host_obj):
+            self._host = host_obj
+
+        def scalar_one_or_none(self):
+            return self._host
+
+    class _DB:
+        def __init__(self, host_obj):
+            self._host = host_obj
+            self.committed = False
+
+        def execute(self, _query):
+            return _Result(self._host)
+
+        def commit(self):
+            self.committed = True
+
+    monkeypatch.setattr(hosts_router, 'permissions_for', lambda user: {'can_manage_users': True})
+    monkeypatch.setattr(hosts_router, 'is_host_visible_to_user', lambda db, user, host_obj: True)
+
+    payload = HostMetadataUpdate(owner='alice')
+    db = _DB(host)
+    user = SimpleNamespace(username='admin')
+
+    out = hosts_router.update_host_metadata('agent-1', payload, db=db, user=user)
+
+    assert db.committed is True
+    assert host.labels['owner'] == 'alice'
+    assert out['host']['labels']['owner'] == 'alice'


### PR DESCRIPTION
## Summary
- treat an explicitly empty owner in host metadata updates as a request to remove labels.owner
- keep other labels untouched when clearing owner
- add isolated regression coverage for assign-owner and clear-owner behavior

## Test Plan
- ./server/.venv/bin/pytest -q server/tests/test_host_owner_clear_api_logic.py server/tests/test_owner_tag_visibility.py server/tests/test_reports_owner_visibility.py
