### PR TITLE
Wire owner field into host metadata save flow

### DIFF
--- a/server/app/templates/fleet-phase3-host-actions.js
+++ b/server/app/templates/fleet-phase3-host-actions.js
@@ -57,15 +57,17 @@
   function populateHostMetadataEditor(host) {
     const nameEl = document.getElementById('host-meta-name');
     const roleEl = document.getElementById('host-meta-role');
+    const ownerEl = document.getElementById('host-meta-owner');
     const list = document.getElementById('host-meta-env-list');
     const statusEl = document.getElementById('host-meta-status');
-    if (!nameEl || !roleEl || !list) return;
+    if (!nameEl || !roleEl || !ownerEl || !list) return;
 
     const labels = (host && typeof host.labels === 'object' && host.labels) ? host.labels : {};
     const envVars = (labels && typeof labels.env_vars === 'object' && labels.env_vars) ? labels.env_vars : {};
 
     nameEl.value = String(host?.hostname || host?.agent_id || '');
     roleEl.value = String(labels.role || '');
+    ownerEl.value = String(labels.owner || '');
     list.innerHTML = '';
     const pairs = Object.entries(envVars);
     if (!pairs.length) appendEnvRow('', '');
@@ -85,6 +87,7 @@
     return {
       hostname: String(src.hostname || '').trim(),
       role: String(src.role || '').trim(),
+      owner: String(src.owner || '').trim(),
       env,
     };
   }
@@ -107,6 +110,7 @@
       const payload = normalizeHostMetadataPayload({
         hostname: document.getElementById('host-meta-name')?.value || '',
         role: document.getElementById('host-meta-role')?.value || '',
+        owner: document.getElementById('host-meta-owner')?.value || '',
         env: collectEnvEntriesFromDom(),
       });
 

--- a/server/app/templates/index.html
+++ b/server/app/templates/index.html
@@ -104,6 +104,7 @@
                 <div class="admin-card-body" style="display:grid;gap:0.45rem;">
                   <input id="host-meta-name" class="host-search" type="text" placeholder="Agent display name / hostname" />
                   <input id="host-meta-role" class="host-search" type="text" placeholder="Role (e.g. web, db, worker)" />
+                  <input id="host-meta-owner" class="host-search" type="text" placeholder="Owner username (blank to clear)" />
                   <div id="host-meta-env-list" style="display:grid;gap:0.35rem;"></div>
                   <div style="display:flex;gap:0.45rem;flex-wrap:wrap;">
                     <button class="btn" id="host-meta-env-add" type="button">Add env entry</button>

--- a/server/tests/frontend/phase3-host-actions-metadata.test.js
+++ b/server/tests/frontend/phase3-host-actions-metadata.test.js
@@ -19,14 +19,16 @@ function loadScript(filePath) {
 describe('phase3 host metadata payload normalization', () => {
   const root = path.resolve(path.dirname(new URL(import.meta.url).pathname), '../../..');
   const scriptPath = path.join(root, 'server/app/templates/fleet-phase3-host-actions.js');
+  const indexPath = path.join(root, 'server/app/templates/index.html');
 
-  it('trims hostname/role and drops blank env keys', () => {
+  it('trims hostname/role/owner and drops blank env keys', () => {
     const ctx = loadScript(scriptPath);
     const fn = ctx.phase3HostActions.normalizeHostMetadataPayload;
 
     const got = fn({
       hostname: '  web-01  ',
       role: '  app  ',
+      owner: '  imre  ',
       env: {
         ' FOO ': '  bar ',
         '': 'x',
@@ -37,7 +39,28 @@ describe('phase3 host metadata payload normalization', () => {
     expect(got).toEqual({
       hostname: 'web-01',
       role: 'app',
+      owner: 'imre',
       env: { FOO: 'bar' },
     });
+  });
+
+  it('preserves explicit blank owner so metadata save can clear host owner access', () => {
+    const ctx = loadScript(scriptPath);
+    const fn = ctx.phase3HostActions.normalizeHostMetadataPayload;
+
+    const got = fn({
+      hostname: 'srv-1',
+      role: 'db',
+      owner: '   ',
+      env: {},
+    });
+
+    expect(got.owner).toBe('');
+  });
+
+  it('renders a host owner field in the metadata editor', () => {
+    const html = fs.readFileSync(indexPath, 'utf8');
+    expect(html).toContain('id="host-meta-owner"');
+    expect(html).toContain('Owner username (blank to clear)');
   });
 });


### PR DESCRIPTION
## Summary
- add an owner input to the host metadata editor
- populate the owner input from current host labels
- include owner in the metadata save payload so blank owner clears access
- add frontend regression coverage for owner payload normalization and metadata editor rendering

## Test Plan
- npm run test:frontend -- phase3-host-actions-metadata.test.js regular-user-owner-visibility.test.js
- ./server/.venv/bin/pytest -q server/tests/test_host_owner_clear_api_logic.py server/tests/test_owner_tag_visibility.py server/tests/test_reports_owner_visibility.py
