### PR TITLE
Validate host owners against existing users

### DIFF
--- a/server/app/routers/hosts.py
+++ b/server/app/routers/hosts.py
@@ -10,7 +10,7 @@ from ..db import get_db
 from ..deps import require_ui_user
 from ..config import settings
 from ..models import Host, HostMetricsSnapshot, HostPackage, HostPackageUpdate, HostLoadMetric
-from ..models import HostCVEStatus, HostUser, PatchCampaign, PatchCampaignHost, Job, JobRun, CVEPackage, CronJob
+from ..models import HostCVEStatus, HostUser, PatchCampaign, PatchCampaignHost, Job, JobRun, CVEPackage, CronJob, AppUser
 from ..services.db_utils import transaction
 from ..services.jobs import create_job_with_runs, push_job_to_agents
 from ..services.hosts import is_host_online, seconds_since_seen
@@ -81,6 +81,11 @@ def update_host_metadata(
     next_role = _clean_optional_str(payload.role, field="role")
     next_owner = _clean_optional_str(payload.owner, field="owner")
     owner_provided = "owner" in provided_fields
+
+    if owner_provided and next_owner:
+        owner_user = db.execute(select(AppUser).where(AppUser.username == next_owner, AppUser.is_active == True)).scalar_one_or_none()  # noqa: E712
+        if not owner_user:
+            raise HTTPException(400, f"owner user '{next_owner}' does not exist")
 
     next_env: dict[str, str] | None = None
     if payload.env is not None:

--- a/server/tests/test_host_owner_clear_api_logic.py
+++ b/server/tests/test_host_owner_clear_api_logic.py
@@ -1,37 +1,46 @@
 from types import SimpleNamespace
 
+import pytest
+from fastapi import HTTPException
+
+
+class _ScalarResult:
+    def __init__(self, value):
+        self._value = value
+
+    def scalar_one_or_none(self):
+        return self._value
+
+
+class _HostLookupDB:
+    def __init__(self, host_obj, owner_user=None):
+        self._host = host_obj
+        self._owner_user = owner_user
+        self.committed = False
+        self._calls = 0
+
+    def execute(self, _query):
+        self._calls += 1
+        if self._calls == 1:
+            return _ScalarResult(self._host)
+        return _ScalarResult(self._owner_user)
+
+    def commit(self):
+        self.committed = True
+
 
 def test_update_host_metadata_clears_owner_when_owner_field_is_present_and_empty(monkeypatch):
     from app.routers import hosts as hosts_router
     from app.schemas import HostMetadataUpdate
 
     host = SimpleNamespace(agent_id='agent-1', hostname='srv-1', labels={'owner': 'imre', 'team': 'ops'})
-
-    class _Result:
-        def __init__(self, host_obj):
-            self._host = host_obj
-
-        def scalar_one_or_none(self):
-            return self._host
-
-    class _DB:
-        def __init__(self, host_obj):
-            self._host = host_obj
-            self.committed = False
-
-        def execute(self, _query):
-            return _Result(self._host)
-
-        def commit(self):
-            self.committed = True
+    db = _HostLookupDB(host)
+    user = SimpleNamespace(username='admin')
 
     monkeypatch.setattr(hosts_router, 'permissions_for', lambda user: {'can_manage_users': True})
     monkeypatch.setattr(hosts_router, 'is_host_visible_to_user', lambda db, user, host_obj: True)
 
     payload = HostMetadataUpdate(owner='')
-    db = _DB(host)
-    user = SimpleNamespace(username='admin')
-
     out = hosts_router.update_host_metadata('agent-1', payload, db=db, user=user)
 
     assert db.committed is True
@@ -40,39 +49,42 @@ def test_update_host_metadata_clears_owner_when_owner_field_is_present_and_empty
     assert 'owner' not in out['host']['labels']
 
 
-def test_update_host_metadata_sets_owner_when_non_empty_owner_is_provided(monkeypatch):
+def test_update_host_metadata_sets_owner_when_existing_user_is_provided(monkeypatch):
     from app.routers import hosts as hosts_router
     from app.schemas import HostMetadataUpdate
 
     host = SimpleNamespace(agent_id='agent-1', hostname='srv-1', labels={'team': 'ops'})
-
-    class _Result:
-        def __init__(self, host_obj):
-            self._host = host_obj
-
-        def scalar_one_or_none(self):
-            return self._host
-
-    class _DB:
-        def __init__(self, host_obj):
-            self._host = host_obj
-            self.committed = False
-
-        def execute(self, _query):
-            return _Result(self._host)
-
-        def commit(self):
-            self.committed = True
+    db = _HostLookupDB(host, owner_user=SimpleNamespace(username='alice', is_active=True))
+    user = SimpleNamespace(username='admin')
 
     monkeypatch.setattr(hosts_router, 'permissions_for', lambda user: {'can_manage_users': True})
     monkeypatch.setattr(hosts_router, 'is_host_visible_to_user', lambda db, user, host_obj: True)
 
     payload = HostMetadataUpdate(owner='alice')
-    db = _DB(host)
-    user = SimpleNamespace(username='admin')
-
     out = hosts_router.update_host_metadata('agent-1', payload, db=db, user=user)
 
     assert db.committed is True
     assert host.labels['owner'] == 'alice'
     assert out['host']['labels']['owner'] == 'alice'
+
+
+def test_update_host_metadata_rejects_nonexistent_owner(monkeypatch):
+    from app.routers import hosts as hosts_router
+    from app.schemas import HostMetadataUpdate
+
+    host = SimpleNamespace(agent_id='agent-1', hostname='srv-1', labels={'team': 'ops'})
+    db = _HostLookupDB(host, owner_user=None)
+    user = SimpleNamespace(username='admin')
+
+    monkeypatch.setattr(hosts_router, 'permissions_for', lambda user: {'can_manage_users': True})
+    monkeypatch.setattr(hosts_router, 'is_host_visible_to_user', lambda db, user, host_obj: True)
+
+    payload = HostMetadataUpdate(owner='ghost-user')
+
+    with pytest.raises(HTTPException) as exc:
+        hosts_router.update_host_metadata('agent-1', payload, db=db, user=user)
+
+    assert exc.value.status_code == 400
+    assert "does not exist" in str(exc.value.detail)
+    assert db.committed is False
+    assert 'owner' not in host.labels


### PR DESCRIPTION
## Summary
- reject non-empty host owner values unless they match an existing active app user
- keep blank owner clears working as before
- add focused regression coverage for valid owner, invalid owner, and owner clearing

## Test Plan
- ./server/.venv/bin/pytest -q server/tests/test_host_owner_clear_api_logic.py server/tests/test_owner_tag_visibility.py server/tests/test_reports_owner_visibility.py
- npm run test:frontend -- phase3-host-actions-metadata.test.js regular-user-owner-visibility.test.js
