### PR TITLE
Add owner sorting in Hosts view

### DIFF
--- a/server/app/templates/fleet-phase3-overview.js
+++ b/server/app/templates/fleet-phase3-overview.js
@@ -375,6 +375,7 @@
     tbody.innerHTML = '';
     for (const it of items) {
       const hostName = it.hostname || it.agent_id;
+      const owner = String(it?.labels?.owner || '').trim();
       const os = `${it.os_id || ''} ${it.os_version || ''}`.trim() || '–';
       const kernel = it.kernel || '–';
       const sec = Number(it.security_updates || 0);
@@ -410,6 +411,7 @@
           </div>
           <div style="color:var(--muted-2);font-size:0.85rem;">${w.escapeHtml(it.agent_id || '')} ${it.ip_address ? '• ' + w.escapeHtml(it.ip_address) : ''}</div>
         </td>
+        <td>${owner ? `<code>${w.escapeHtml(owner)}</code>` : '<span class="status-muted">—</span>'}</td>
         <td>${w.escapeHtml(os)}</td>
         <td><code>${w.escapeHtml(kernel)}</code></td>
         <td style="text-align:right;"><b>${sec}</b></td>

--- a/server/app/templates/index.html
+++ b/server/app/templates/index.html
@@ -509,6 +509,7 @@
             <label style="color:var(--muted-2);font-size:0.9rem;">Sort</label>
           <select id="hosts-sort" class="host-search" style="width:auto;padding:0.35rem 0.5rem;">
             <option value="hostname" selected>Host</option>
+            <option value="owner">Owner</option>
             <option value="os_version">OS</option>
             <option value="updates">Pending updates</option>
             <option value="security_updates">Security updates</option>
@@ -538,6 +539,7 @@
               <tr>
                 <th style="width:36px;"><input type="checkbox" id="hosts-select-all" /></th>
                 <th class="sortable-col" id="hosts-th-host" title="Sort by host" tabindex="0" role="button">Host <span class="sort-indicator" aria-hidden="true">↕</span></th>
+                <th class="sortable-col" id="hosts-th-owner" title="Sort by owner" tabindex="0" role="button">Owner <span class="sort-indicator" aria-hidden="true">↕</span></th>
                 <th class="sortable-col" id="hosts-th-os" title="Sort by OS" tabindex="0" role="button">OS <span class="sort-indicator" aria-hidden="true">↕</span></th>
                 <th>Kernel</th>
                 <th class="sortable-col" style="text-align:right;" id="hosts-th-sec" title="Sort by security updates" tabindex="0" role="button">Security pkgs <span class="sort-indicator" aria-hidden="true">↕</span></th>
@@ -3454,6 +3456,7 @@
       const hostsOrderSel = document.getElementById('hosts-order');
       updateHostsSortIndicators(hostsSortSel?.value || 'hostname', hostsOrderSel?.value || 'asc');
       bindSortableHeader('hosts-th-host', () => setSort('hostname'));
+      bindSortableHeader('hosts-th-owner', () => setSort('owner'));
       bindSortableHeader('hosts-th-os', () => setSort('os_version'));
       bindSortableHeader('hosts-th-upd', () => setSort('updates'));
       bindSortableHeader('hosts-th-sec', () => setSort('security_updates'));

--- a/server/tests/frontend/hosts-sort-owner.test.js
+++ b/server/tests/frontend/hosts-sort-owner.test.js
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+describe('hosts owner sorting UI', () => {
+  const root = path.resolve(path.dirname(new URL(import.meta.url).pathname), '../../..');
+  const htmlPath = path.join(root, 'server/app/templates/index.html');
+  const overviewPath = path.join(root, 'server/app/templates/fleet-phase3-overview.js');
+  const html = fs.readFileSync(htmlPath, 'utf8');
+  const overview = fs.readFileSync(overviewPath, 'utf8');
+
+  it('offers owner in the Hosts sort dropdown and exposes an Owner sortable header', () => {
+    expect(html).toContain('<option value="owner">Owner</option>');
+    expect(html).toContain('id="hosts-th-owner"');
+    expect(html).toContain('title="Sort by owner"');
+    expect(html).toContain("bindSortableHeader('hosts-th-owner', () => setSort('owner'));");
+  });
+
+  it('renders the owner value as its own Hosts table column', () => {
+    expect(overview).toContain("const owner = String(it?.labels?.owner || '').trim();");
+    expect(overview).toContain("<td>${owner ? `<code>${w.escapeHtml(owner)}</code>` : '<span class=\"status-muted\">—</span>'}</td>");
+  });
+
+  it('keeps owner sorting implemented in the hosts table loader', () => {
+    expect(overview).toContain("const effectiveSort = sort === 'owner' ? 'hostname' : sort;");
+    expect(overview).toContain("if (sort === 'owner') {");
+    expect(overview).toContain("const ownerCmp = ao.localeCompare(bo, undefined, { sensitivity: 'base' });");
+  });
+});


### PR DESCRIPTION
## Summary
- add Owner to the Hosts sort dropdown
- add a visible Owner column in the Hosts table
- wire the Owner header into the existing owner sort logic
- add focused frontend regression coverage for owner sort UI and rendering

## Test Plan
- npm run test:frontend -- hosts-sort-owner.test.js phase3-host-actions-metadata.test.js
