### PR TITLE
Add owner filtering in Hosts view

### DIFF
--- a/server/app/templates/fleet-phase3-host-filters-ui.js
+++ b/server/app/templates/fleet-phase3-host-filters-ui.js
@@ -10,6 +10,7 @@
     const searchEl = document.getElementById('host-search');
     const envSel = document.getElementById('label-env');
     const roleSel = document.getElementById('label-role');
+    const ownerSel = document.getElementById('label-owner');
     const labelsClearBtn = document.getElementById('labels-clear');
     const labelsSection = document.getElementById('labels-filter-section');
     const labelsToggle = document.getElementById('labels-filter-toggle');
@@ -98,6 +99,7 @@
         hostSearchQuery: searchEl?.value || '',
         labelEnvFilter: envSel?.value || '',
         labelRoleFilter: roleSel?.value || '',
+        labelOwnerFilter: ownerSel?.value || '',
       };
     }
 
@@ -116,15 +118,18 @@
       const hostSearchQuery = String(view.hostSearchQuery || '');
       const labelEnv = String(view.labelEnvFilter || '');
       const labelRole = String(view.labelRoleFilter || '');
+      const labelOwner = String(view.labelOwnerFilter || '');
 
       if (searchEl) searchEl.value = hostSearchQuery;
       if (envSel) envSel.value = labelEnv;
       if (roleSel) roleSel.value = labelRole;
+      if (ownerSel) ownerSel.value = labelOwner;
 
       syncSelectionState('hostSearchQuery', hostSearchQuery);
       syncSelectionState('labelEnvFilter', labelEnv);
       syncSelectionState('labelRoleFilter', labelRole);
-      setPatch({ hostSearchQuery, labelEnvFilter: labelEnv, labelRoleFilter: labelRole });
+      syncSelectionState('labelOwnerFilter', labelOwner);
+      setPatch({ hostSearchQuery, labelEnvFilter: labelEnv, labelRoleFilter: labelRole, labelOwnerFilter: labelOwner });
       applyHostFilters();
 
       if (options.setUrl !== false) {
@@ -146,7 +151,7 @@
     setVulnOpen(false);
 
     labelsToggle?.addEventListener('click', function (e) {
-      if (e.target && (e.target.id === 'label-env' || e.target.id === 'label-role')) return;
+      if (e.target && (e.target.id === 'label-env' || e.target.id === 'label-role' || e.target.id === 'label-owner')) return;
       e.preventDefault();
       const isOpen = labelsSection?.classList.contains('open');
       setLabelsOpen(!isOpen);
@@ -166,20 +171,25 @@
     function onLabelsChanged() {
       const env = envSel?.value || '';
       const role = roleSel?.value || '';
+      const owner = ownerSel?.value || '';
       syncSelectionState('labelEnvFilter', env);
       syncSelectionState('labelRoleFilter', role);
-      setPatch({ labelEnvFilter: env, labelRoleFilter: role });
+      syncSelectionState('labelOwnerFilter', owner);
+      setPatch({ labelEnvFilter: env, labelRoleFilter: role, labelOwnerFilter: owner });
       applyHostFilters();
     }
     envSel?.addEventListener('change', onLabelsChanged);
     roleSel?.addEventListener('change', onLabelsChanged);
+    ownerSel?.addEventListener('change', onLabelsChanged);
     labelsClearBtn?.addEventListener('click', function (e) {
       e.preventDefault();
       if (envSel) envSel.value = '';
       if (roleSel) roleSel.value = '';
+      if (ownerSel) ownerSel.value = '';
       syncSelectionState('labelEnvFilter', '');
       syncSelectionState('labelRoleFilter', '');
-      setPatch({ labelEnvFilter: '', labelRoleFilter: '' });
+      syncSelectionState('labelOwnerFilter', '');
+      setPatch({ labelEnvFilter: '', labelRoleFilter: '', labelOwnerFilter: '' });
       applyHostFilters();
     });
 

--- a/server/app/templates/fleet-phase3-host-list.js
+++ b/server/app/templates/fleet-phase3-host-list.js
@@ -2,32 +2,41 @@
   function rebuildLabelFilterOptions(ctx) {
     const envSel = document.getElementById('label-env');
     const roleSel = document.getElementById('label-role');
-    if (!envSel || !roleSel) return;
+    const ownerSel = document.getElementById('label-owner');
+    if (!envSel || !roleSel || !ownerSel) return;
 
     const hosts = ctx.getAllHosts();
     const envVals = new Set();
     const roleVals = new Set();
+    const ownerVals = new Set();
     (hosts || []).forEach(h => {
       const env = (w.hostLabel(h, 'env') || '').trim();
       const role = (w.hostLabel(h, 'role') || '').trim();
+      const owner = (w.hostLabel(h, 'owner') || '').trim();
       if (env) envVals.add(env);
       if (role) roleVals.add(role);
+      if (owner) ownerVals.add(owner);
     });
 
     const envList = Array.from(envVals).sort((a, b) => a.localeCompare(b));
     const roleList = Array.from(roleVals).sort((a, b) => a.localeCompare(b));
+    const ownerList = Array.from(ownerVals).sort((a, b) => a.localeCompare(b));
 
     const prevEnv = envSel.value || '';
     const prevRole = roleSel.value || '';
+    const prevOwner = ownerSel.value || '';
 
     envSel.innerHTML = `<option value="">Env: Any</option>` + envList.map(v => `<option value="${w.escapeHtml(v)}">${w.escapeHtml(v)}</option>`).join('');
     roleSel.innerHTML = `<option value="">Role: Any</option>` + roleList.map(v => `<option value="${w.escapeHtml(v)}">${w.escapeHtml(v)}</option>`).join('');
+    ownerSel.innerHTML = `<option value="">Owner: Any</option>` + ownerList.map(v => `<option value="${w.escapeHtml(v)}">${w.escapeHtml(v)}</option>`).join('');
 
     envSel.value = (prevEnv && envList.includes(prevEnv)) ? prevEnv : '';
     roleSel.value = (prevRole && roleList.includes(prevRole)) ? prevRole : '';
+    ownerSel.value = (prevOwner && ownerList.includes(prevOwner)) ? prevOwner : '';
 
     ctx.setLabelEnvFilter(envSel.value || '');
     ctx.setLabelRoleFilter(roleSel.value || '');
+    ctx.setLabelOwnerFilter(ownerSel.value || '');
   }
 
   function applyHostFilters(ctx) {
@@ -39,8 +48,10 @@
 
     const labelEnvFilter = ctx.getLabelEnvFilter();
     const labelRoleFilter = ctx.getLabelRoleFilter();
+    const labelOwnerFilter = ctx.getLabelOwnerFilter();
     if (labelEnvFilter) filtered = filtered.filter(h => (w.hostLabel(h, 'env') || '') === labelEnvFilter);
     if (labelRoleFilter) filtered = filtered.filter(h => (w.hostLabel(h, 'role') || '') === labelRoleFilter);
+    if (labelOwnerFilter) filtered = filtered.filter(h => (w.hostLabel(h, 'owner') || '') === labelOwnerFilter);
 
     if (q) {
       filtered = filtered.filter(h => {

--- a/server/app/templates/index.html
+++ b/server/app/templates/index.html
@@ -385,6 +385,11 @@
                     <option value="">Role: Any</option>
                   </select>
                 </div>
+                <div class="vuln-row">
+                  <select id="label-owner" class="host-search">
+                    <option value="">Owner: Any</option>
+                  </select>
+                </div>
                 <div class="vuln-actions">
                   <button class="btn" id="labels-clear">Clear</button>
                 </div>
@@ -1507,6 +1512,7 @@
       hostSearchQuery: '',
       labelEnvFilter: '',
       labelRoleFilter: '',
+      labelOwnerFilter: '',
       vulnFilteredAgentIds: null,
       selectedAgentIds: new Set(),
       lastRenderedAgentIds: [],
@@ -1518,6 +1524,7 @@
         hostSearchQuery: '',
         labelEnvFilter: '',
         labelRoleFilter: '',
+        labelOwnerFilter: '',
         vulnFilteredAgentIds: null,
         selectedAgentIds: new Set(),
         lastRenderedAgentIds: [],
@@ -1526,6 +1533,7 @@
     let hostSearchQuery = hostFilterSelectionDefaults.hostSearchQuery;
     let labelEnvFilter = hostFilterSelectionDefaults.labelEnvFilter;
     let labelRoleFilter = hostFilterSelectionDefaults.labelRoleFilter;
+    let labelOwnerFilter = hostFilterSelectionDefaults.labelOwnerFilter;
     let vulnFilteredAgentIds = hostFilterSelectionDefaults.vulnFilteredAgentIds; // Set<string> or null
     let selectedAgentIds = hostFilterSelectionDefaults.selectedAgentIds;
     let lastRenderedAgentIds = hostFilterSelectionDefaults.lastRenderedAgentIds; // string[]
@@ -1562,6 +1570,8 @@
         setLabelEnvFilter: (v) => { labelEnvFilter = syncHostFilterSelectionState('labelEnvFilter', v); return labelEnvFilter; },
         getLabelRoleFilter: () => labelRoleFilter,
         setLabelRoleFilter: (v) => { labelRoleFilter = syncHostFilterSelectionState('labelRoleFilter', v); return labelRoleFilter; },
+        getLabelOwnerFilter: () => labelOwnerFilter,
+        setLabelOwnerFilter: (v) => { labelOwnerFilter = syncHostFilterSelectionState('labelOwnerFilter', v); return labelOwnerFilter; },
         getVulnFilteredAgentIds: () => vulnFilteredAgentIds,
         getSelectedAgentIds: () => selectedAgentIds,
         setLastRenderedAgentIds: (v) => { lastRenderedAgentIds = syncHostFilterSelectionState('lastRenderedAgentIds', v); return lastRenderedAgentIds; },
@@ -2886,6 +2896,7 @@
           hostSearchQuery,
           labelEnvFilter,
           labelRoleFilter,
+          labelOwnerFilter,
           vulnFilteredAgentIds,
           selectedAgentIds,
           lastRenderedAgentIds,
@@ -2901,6 +2912,7 @@
           if (Object.prototype.hasOwnProperty.call(patch, 'hostSearchQuery')) hostSearchQuery = syncHostFilterSelectionState('hostSearchQuery', patch.hostSearchQuery || '');
           if (Object.prototype.hasOwnProperty.call(patch, 'labelEnvFilter')) labelEnvFilter = syncHostFilterSelectionState('labelEnvFilter', patch.labelEnvFilter || '');
           if (Object.prototype.hasOwnProperty.call(patch, 'labelRoleFilter')) labelRoleFilter = syncHostFilterSelectionState('labelRoleFilter', patch.labelRoleFilter || '');
+          if (Object.prototype.hasOwnProperty.call(patch, 'labelOwnerFilter')) labelOwnerFilter = syncHostFilterSelectionState('labelOwnerFilter', patch.labelOwnerFilter || '');
           if (Object.prototype.hasOwnProperty.call(patch, 'vulnFilteredAgentIds')) vulnFilteredAgentIds = syncHostFilterSelectionState('vulnFilteredAgentIds', patch.vulnFilteredAgentIds);
           if (Object.prototype.hasOwnProperty.call(patch, 'selectedAgentIds')) selectedAgentIds = syncHostFilterSelectionState('selectedAgentIds', (patch.selectedAgentIds instanceof Set) ? patch.selectedAgentIds : new Set());
           if (Object.prototype.hasOwnProperty.call(patch, 'lastRenderedAgentIds')) lastRenderedAgentIds = syncHostFilterSelectionState('lastRenderedAgentIds', Array.isArray(patch.lastRenderedAgentIds) ? patch.lastRenderedAgentIds : []);
@@ -3062,6 +3074,7 @@
         getCurrentAgentId: () => currentAgentId,
         getLabelEnvFilter: () => labelEnvFilter,
         getLabelRoleFilter: () => labelRoleFilter,
+        getLabelOwnerFilter: () => labelOwnerFilter,
         getVulnFilteredAgentIds: () => vulnFilteredAgentIds,
         setAllHosts: (hosts) => {
           allHosts = syncHostFilterSelectionState('allHosts', Array.isArray(hosts) ? hosts : []);

--- a/server/tests/frontend/hosts-filter-owner.test.js
+++ b/server/tests/frontend/hosts-filter-owner.test.js
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+
+describe('hosts owner filter UI', () => {
+  const root = path.resolve(path.dirname(new URL(import.meta.url).pathname), '../../..');
+  const htmlPath = path.join(root, 'server/app/templates/index.html');
+  const hostListPath = path.join(root, 'server/app/templates/fleet-phase3-host-list.js');
+  const filtersUiPath = path.join(root, 'server/app/templates/fleet-phase3-host-filters-ui.js');
+  const html = fs.readFileSync(htmlPath, 'utf8');
+  const hostList = fs.readFileSync(hostListPath, 'utf8');
+  const filtersUi = fs.readFileSync(filtersUiPath, 'utf8');
+
+  it('renders an Owner filter control in the Hosts filters', () => {
+    expect(html).toContain('id="label-owner"');
+    expect(html).toContain('Owner: Any');
+  });
+
+  it('populates and applies owner filter values in host list filtering', () => {
+    expect(hostList).toContain("const ownerSel = document.getElementById('label-owner');");
+    expect(hostList).toContain('const ownerVals = new Set();');
+    expect(hostList).toContain('ctx.setLabelOwnerFilter(ownerSel.value || \'\');');
+    expect(hostList).toContain('const labelOwnerFilter = ctx.getLabelOwnerFilter();');
+    expect(hostList).toContain("if (labelOwnerFilter) filtered = filtered.filter(h => (w.hostLabel(h, 'owner') || '') === labelOwnerFilter);");
+  });
+
+  it('persists owner filter in filter UI state and saved views', () => {
+    expect(filtersUi).toContain("const ownerSel = document.getElementById('label-owner');");
+    expect(filtersUi).toContain('labelOwnerFilter: ownerSel?.value || \'\'');
+    expect(filtersUi).toContain('const labelOwner = String(view.labelOwnerFilter || \'\');');
+    expect(filtersUi).toContain("syncSelectionState('labelOwnerFilter', labelOwner);");
+    expect(filtersUi).toContain("ownerSel?.addEventListener('change', onLabelsChanged);");
+  });
+});


### PR DESCRIPTION
## Summary
- add an Owner filter control to the Hosts filters panel
- wire owner filter through host list state, saved views, and filter application
- populate owner filter options from visible host metadata
- add focused frontend regression coverage for owner filter UI/state behavior

## Test Plan
- npm run test:frontend -- hosts-filter-owner.test.js hosts-sort-owner.test.js
