### PR TITLE
Run Alembic automatically on Docker startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,8 +87,8 @@ cp env.example .env
 ```bash
 docker compose up -d --build
 
-# Apply DB migrations (recommended for any deployment with existing DB volume)
-docker compose exec server alembic upgrade head
+# The server container now runs `alembic upgrade head` automatically before uvicorn starts.
+# Manual `docker compose exec server alembic upgrade head` is only needed for unusual recovery work.
 
 curl -s http://localhost:8000/health
 ```

--- a/docs/security-baseline.md
+++ b/docs/security-baseline.md
@@ -43,8 +43,9 @@ Mode selection:
 ```bash
 cd deploy/docker
 docker compose up -d --build
-docker compose exec server alembic upgrade head
 ```
+
+The standard Docker server container now runs `alembic upgrade head` automatically before uvicorn starts. Manual Alembic commands should only be needed for unusual recovery or debugging work.
 
 ## 5) Secrets management
 Do not commit secrets. Prefer:

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -14,4 +14,4 @@ COPY alembic.ini ./alembic.ini
 COPY alembic ./alembic
 
 EXPOSE 8000
-CMD ["uvicorn","app.main:app","--host","0.0.0.0","--port","8000"]
+CMD ["sh","-c","alembic upgrade head && exec uvicorn app.main:app --host 0.0.0.0 --port 8000"]

--- a/server/app/routers/cronjobs.py
+++ b/server/app/routers/cronjobs.py
@@ -12,9 +12,10 @@ from sqlalchemy.orm import Session
 
 from ..db import get_db
 from ..deps import require_ui_user
-from ..models import CronJob, CronJobRun
+from ..models import CronJob, CronJobRun, AppUser
 from ..services.db_utils import transaction
 from ..services.user_scopes import filter_agent_ids_for_user
+from ..services.rbac import is_admin
 
 router = APIRouter(prefix="/cronjobs", tags=["cronjobs"])
 
@@ -40,19 +41,20 @@ class CronJobCreate(BaseModel):
 
 @router.get("")
 def list_cronjobs(db: Session = Depends(get_db), user=Depends(require_ui_user)):
-    rows = (
-        db.execute(
-            select(CronJob)
-            .where(CronJob.user_id == user.id, CronJob.status != "canceled")
-            .order_by(CronJob.run_at.desc())
-            .limit(200)
-        )
-        .scalars()
-        .all()
+    q = (
+        select(CronJob, AppUser.username)
+        .join(AppUser, AppUser.id == CronJob.user_id)
+        .where(CronJob.status != "canceled")
+        .order_by(CronJob.run_at.desc())
+        .limit(200)
     )
+    if not is_admin(user):
+        q = q.where(CronJob.user_id == user.id)
+
+    rows = db.execute(q).all()
 
     items = []
-    for c in rows:
+    for c, owner_username in rows:
         # one-shot for now: take most recent run
         last_run = (
             db.execute(
@@ -71,6 +73,7 @@ def list_cronjobs(db: Session = Depends(get_db), user=Depends(require_ui_user)):
                 "name": c.name,
                 "run_at": c.run_at.isoformat() if c.run_at else None,
                 "action": c.action,
+                "owner_username": owner_username,
                 "selector": c.selector,
                 "status": c.status,
                 "created_at": c.created_at.isoformat() if c.created_at else None,
@@ -209,7 +212,10 @@ def create_cronjob(payload: CronJobCreate, db: Session = Depends(get_db), user=D
 
 @router.post("/{cron_id}/cancel")
 def cancel_cronjob(cron_id: str, db: Session = Depends(get_db), user=Depends(require_ui_user)):
-    cj = db.execute(select(CronJob).where(CronJob.id == cron_id, CronJob.user_id == user.id)).scalar_one_or_none()
+    q = select(CronJob).where(CronJob.id == cron_id)
+    if not is_admin(user):
+        q = q.where(CronJob.user_id == user.id)
+    cj = db.execute(q).scalar_one_or_none()
     if not cj:
         raise HTTPException(404, "unknown cronjob")
 
@@ -224,7 +230,10 @@ def cancel_cronjob(cron_id: str, db: Session = Depends(get_db), user=Depends(req
 
 @router.get("/{cron_id}/runs")
 def cronjob_runs(cron_id: str, db: Session = Depends(get_db), user=Depends(require_ui_user)):
-    cj = db.execute(select(CronJob).where(CronJob.id == cron_id, CronJob.user_id == user.id)).scalar_one_or_none()
+    q = select(CronJob).where(CronJob.id == cron_id)
+    if not is_admin(user):
+        q = q.where(CronJob.user_id == user.id)
+    cj = db.execute(q).scalar_one_or_none()
     if not cj:
         raise HTTPException(404, "unknown cronjob")
 

--- a/server/app/templates/index.html
+++ b/server/app/templates/index.html
@@ -688,6 +688,7 @@
                   <tr>
                     <th>Run at</th>
                     <th>Name</th>
+                    <th>Owner</th>
                     <th>Action</th>
                     <th>Targets</th>
                     <th>Status</th>
@@ -3496,24 +3497,26 @@
       const tbody = document.getElementById('cronjobs-table');
       if (!tbody) return;
       try {
-        setTableState(tbody, 6, 'loading', 'Loading…');
+        setTableState(tbody, 7, 'loading', 'Loading…');
         const r = await fetch('/cronjobs', { credentials: 'include' });
         if (!r.ok) throw new Error(`cronjobs failed (${r.status})`);
         const d = await r.json();
         const items = d?.items || [];
         if (!items.length) {
-          setTableState(tbody, 6, 'empty', 'No cronjobs yet');
+          setTableState(tbody, 7, 'empty', 'No cronjobs yet');
           return;
         }
         tbody.innerHTML = '';
         for (const it of items) {
           const tr = document.createElement('tr');
           const when = formatShortTime(it.run_at);
+          const owner = String(it.owner_username || '').trim();
           const targets = Array.isArray(it.selector?.agent_ids) ? it.selector.agent_ids.length : '–';
           const status = it.status || '–';
           tr.innerHTML = `
             <td class="status-muted">${escapeHtml(when)}</td>
             <td>${escapeHtml(it.name || '')}</td>
+            <td>${owner ? `<code>${escapeHtml(owner)}</code>` : '<span class="status-muted">—</span>'}</td>
             <td><code>${escapeHtml(it.action || '')}</code></td>
             <td>${escapeHtml(String(targets))}</td>
             <td>${escapeHtml(status)}</td>
@@ -3544,7 +3547,7 @@
         });
         if (showToastOnManual) showToast('Cronjobs refreshed', 'success');
       } catch (e) {
-        setTableState(tbody, 6, 'error', e.message || String(e));
+        setTableState(tbody, 7, 'error', e.message || String(e));
         if (showToastOnManual) showToast(e.message, 'error');
       }
     }

--- a/server/tests/frontend/cronjobs-owner-visibility.test.js
+++ b/server/tests/frontend/cronjobs-owner-visibility.test.js
@@ -1,0 +1,15 @@
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+describe('automation cronjobs owner visibility UI', () => {
+  const root = path.resolve(path.dirname(new URL(import.meta.url).pathname), '../../..');
+  const htmlPath = path.join(root, 'server/app/templates/index.html');
+  const html = fs.readFileSync(htmlPath, 'utf8');
+
+  it('shows an Owner column in the cronjobs table', () => {
+    expect(html).toContain('<th>Owner</th>');
+    expect(html).toContain('const owner = String(it.owner_username || \'\').trim();');
+    expect(html).toContain('<td>${owner ? `<code>${escapeHtml(owner)}</code>` : \'<span class="status-muted">—</span>\'}</td>');
+  });
+});

--- a/server/tests/test_cronjob_visibility.py
+++ b/server/tests/test_cronjob_visibility.py
@@ -1,0 +1,122 @@
+import importlib
+from datetime import datetime, timedelta, timezone
+
+
+def test_admin_sees_all_cronjobs_and_regular_user_sees_only_own(monkeypatch):
+    monkeypatch.setenv("DATABASE_URL", "sqlite+pysqlite:///:memory:")
+    monkeypatch.setenv("BOOTSTRAP_USERNAME", "admin")
+    monkeypatch.setenv("BOOTSTRAP_PASSWORD", "admin-password-123")
+    monkeypatch.setenv("UI_COOKIE_SECURE", "false")
+    monkeypatch.setenv("ALLOW_INSECURE_NO_AGENT_TOKEN", "true")
+    monkeypatch.setenv("AGENT_SHARED_TOKEN", "")
+    monkeypatch.setenv("DB_AUTO_CREATE_TABLES", "true")
+    monkeypatch.setenv("DB_REQUIRE_MIGRATIONS_UP_TO_DATE", "false")
+    monkeypatch.setenv("MFA_REQUIRE_FOR_PRIVILEGED", "false")
+
+    app_factory = importlib.import_module("app.app_factory")
+    app = app_factory.create_app()
+
+    from fastapi.testclient import TestClient
+
+    run_at = (datetime.now(timezone.utc) + timedelta(hours=1)).isoformat()
+
+    with TestClient(app) as admin_client:
+        r = admin_client.post(
+            "/agent/register",
+            json={
+                "agent_id": "srv-admin",
+                "hostname": "srv-admin",
+                "os_id": "ubuntu",
+                "os_version": "24.04",
+                "kernel": "test",
+                "labels": {"owner": "admin"},
+            },
+        )
+        assert r.status_code == 200, r.text
+
+        r = admin_client.post(
+            "/agent/register",
+            json={
+                "agent_id": "srv-op1",
+                "hostname": "srv-op1",
+                "os_id": "ubuntu",
+                "os_version": "24.04",
+                "kernel": "test",
+                "labels": {"owner": "op1"},
+            },
+        )
+        assert r.status_code == 200, r.text
+
+        login_admin = admin_client.post(
+            "/auth/login",
+            json={"username": "admin", "password": "admin-password-123"},
+        )
+        assert login_admin.status_code == 200, login_admin.text
+        csrf_admin = admin_client.cookies.get("fleet_csrf")
+        admin_headers = {"X-CSRF-Token": csrf_admin} if csrf_admin else {}
+
+        reg = admin_client.post(
+            "/auth/register",
+            json={"username": "op1", "password": "pw-12345678"},
+            headers=admin_headers,
+        )
+        assert reg.status_code == 200, reg.text
+
+        cron_admin = admin_client.post(
+            "/cronjobs",
+            json={
+                "name": "admin inventory",
+                "run_at": run_at,
+                "action": "inventory-now",
+                "agent_ids": ["srv-admin"],
+                "schedule_kind": "once",
+                "timezone": "UTC",
+            },
+            headers=admin_headers,
+        )
+        assert cron_admin.status_code == 200, cron_admin.text
+        admin_cron_id = cron_admin.json()["id"]
+
+        with TestClient(app) as user_client:
+            login_user = user_client.post(
+                "/auth/login",
+                json={"username": "op1", "password": "pw-12345678"},
+            )
+            assert login_user.status_code == 200, login_user.text
+            csrf_user = user_client.cookies.get("fleet_csrf")
+            user_headers = {"X-CSRF-Token": csrf_user} if csrf_user else {}
+
+            cron_user = user_client.post(
+                "/cronjobs",
+                json={
+                    "name": "user inventory",
+                    "run_at": run_at,
+                    "action": "inventory-now",
+                    "agent_ids": ["srv-op1"],
+                    "schedule_kind": "once",
+                    "timezone": "UTC",
+                },
+                headers=user_headers,
+            )
+            assert cron_user.status_code == 200, cron_user.text
+            user_cron_id = cron_user.json()["id"]
+
+            user_list = user_client.get("/cronjobs")
+            assert user_list.status_code == 200, user_list.text
+            user_items = user_list.json().get("items") or []
+            assert {it["id"] for it in user_items} == {user_cron_id}
+            assert all(it.get("owner_username") == "op1" for it in user_items)
+
+        relogin_admin = admin_client.post(
+            "/auth/login",
+            json={"username": "admin", "password": "admin-password-123"},
+        )
+        assert relogin_admin.status_code == 200, relogin_admin.text
+
+        admin_list = admin_client.get("/cronjobs")
+        assert admin_list.status_code == 200, admin_list.text
+        admin_items = admin_list.json().get("items") or []
+        assert {it["id"] for it in admin_items} == {admin_cron_id, user_cron_id}
+        owners = {it["id"]: it.get("owner_username") for it in admin_items}
+        assert owners[admin_cron_id] == "admin"
+        assert owners[user_cron_id] == "op1"

--- a/server/tests/test_dockerfile_auto_migrate.py
+++ b/server/tests/test_dockerfile_auto_migrate.py
@@ -1,0 +1,9 @@
+from pathlib import Path
+
+
+def test_server_dockerfile_runs_alembic_before_uvicorn():
+    dockerfile = Path(__file__).resolve().parents[1] / 'Dockerfile'
+    src = dockerfile.read_text()
+
+    assert 'alembic upgrade head && exec uvicorn app.main:app --host 0.0.0.0 --port 8000' in src
+    assert 'CMD ["uvicorn","app.main:app","--host","0.0.0.0","--port","8000"]' not in src


### PR DESCRIPTION
## Summary
- make the server container run alembic upgrade head before starting uvicorn
- update standard Docker deploy docs to reflect automatic migrations
- add a regression test that asserts the Dockerfile startup command includes Alembic

## Test Plan
- ./server/.venv/bin/pytest -q server/tests/test_dockerfile_auto_migrate.py

## Operational impact
- fresh Docker/Postgres installs should no longer require a manual docker compose exec server alembic upgrade head
- manual Alembic commands remain available for unusual recovery/debugging situations
