### PR TITLE
Add host metrics snapshots migration

### DIFF
--- a/server/alembic/versions/20260419_00_host_metrics_snapshots.py
+++ b/server/alembic/versions/20260419_00_host_metrics_snapshots.py
@@ -1,0 +1,44 @@
+"""host metrics snapshots table
+
+Revision ID: 20260419_00
+Revises: 20260414_00
+Create Date: 2026-04-19
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+revision = "20260419_00"
+down_revision = "20260414_00"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "host_metrics_snapshots",
+        sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("agent_id", sa.String(), nullable=False),
+        sa.Column("disk_percent_used", sa.String(), nullable=True),
+        sa.Column("mem_percent_used", sa.String(), nullable=True),
+        sa.Column("load_1min", sa.String(), nullable=True),
+        sa.Column("vcpus", sa.Integer(), nullable=True),
+        sa.Column("recorded_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index("ix_host_metrics_snapshots_agent_id", "host_metrics_snapshots", ["agent_id"])
+    op.create_index("ix_host_metrics_snapshots_recorded_at", "host_metrics_snapshots", ["recorded_at"])
+    op.create_index(
+        "ix_host_metrics_snapshots_agent_recorded",
+        "host_metrics_snapshots",
+        ["agent_id", "recorded_at"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_host_metrics_snapshots_agent_recorded", table_name="host_metrics_snapshots")
+    op.drop_index("ix_host_metrics_snapshots_recorded_at", table_name="host_metrics_snapshots")
+    op.drop_index("ix_host_metrics_snapshots_agent_id", table_name="host_metrics_snapshots")
+    op.drop_table("host_metrics_snapshots")

--- a/server/app/routers/dashboard.py
+++ b/server/app/routers/dashboard.py
@@ -511,8 +511,8 @@ async def dashboard_attention(
                 except Exception:
                     pass
     except Exception:
-        # Cache is best-effort
-        pass
+        # Cache is best-effort. Roll back so a failed snapshot query does not poison the rest of the request.
+        db.rollback()
 
     # Live metrics (disk % and cpu load ratio)
     # Only query hosts missing recent cached metrics.

--- a/server/tests/test_dashboard_attention_metrics_resilience.py
+++ b/server/tests/test_dashboard_attention_metrics_resilience.py
@@ -1,0 +1,19 @@
+from pathlib import Path
+
+
+def test_dashboard_attention_rolls_back_after_best_effort_metrics_cache_failure():
+    path = Path(__file__).resolve().parents[1] / 'app' / 'routers' / 'dashboard.py'
+    src = path.read_text()
+
+    assert 'Cache is best-effort. Roll back so a failed snapshot query does not poison the rest of the request.' in src
+    assert 'db.rollback()' in src
+
+
+def test_host_metrics_snapshots_migration_exists():
+    path = Path(__file__).resolve().parents[1] / 'alembic' / 'versions' / '20260419_00_host_metrics_snapshots.py'
+    src = path.read_text()
+
+    assert 'revision = "20260419_00"' in src
+    assert 'down_revision = "20260414_00"' in src
+    assert 'op.create_table(' in src
+    assert '"host_metrics_snapshots"' in src


### PR DESCRIPTION
## Summary
- add the missing Alembic migration for host_metrics_snapshots
- roll back the SQLAlchemy session when the dashboard attention metrics-cache read fails
- add focused regression coverage for the migration file and rollback guard

## Why
Fresh databases were missing host_metrics_snapshots even though the ORM model existed. The dashboard attention route swallowed the first snapshot query failure without a rollback, which left Postgres in an aborted transaction state and caused Disk Usage / Memory / vCPU / IP widgets to fail with InFailedSqlTransaction.

## Test Plan
- ./server/.venv/bin/pytest -q server/tests/test_dashboard_attention_metrics_resilience.py

## After merge on the affected deployment
- docker compose up -d --build
- if the old container is already running, also run: docker compose exec server alembic upgrade head
