### PR TITLE
Pin Trivy to a real release version

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -69,7 +69,7 @@ jobs:
       - name: Trivy filesystem scan
         uses: aquasecurity/trivy-action@v0.35.0
         with:
-          version: latest
+          version: v0.70.0
           cache: false
           scan-type: fs
           scan-ref: .
@@ -80,7 +80,7 @@ jobs:
       - name: Trivy config scan (IaC)
         uses: aquasecurity/trivy-action@v0.35.0
         with:
-          version: latest
+          version: v0.70.0
           cache: false
           scan-type: config
           scan-ref: deploy


### PR DESCRIPTION
## Summary
- replace the broken Trivy input version=latest with a real release tag
- pin both filesystem and config scans to Trivy v0.70.0

## Why
PR #72 failed in Security before scanning the repo because setup-trivy could not resolve the literal input version=latest.

## Test Plan
- verified the workflow now contains version: v0.70.0 for both Trivy steps
- this change is intended to fix the GitHub Security workflow failure directly
