### PR TITLE
Harden agent API authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,10 +230,11 @@ All agent endpoints require a shared token (required by default):
 - Server: `AGENT_SHARED_TOKEN`
 - Agent: `FLEET_AGENT_TOKEN`
 
-For local development only, you can bypass this requirement by setting:
+For local development only, you can relax this requirement by setting:
 - `ALLOW_INSECURE_NO_AGENT_TOKEN=true`
 
-Do **not** use that on anything exposed beyond a trusted LAN.
+That bypass is now limited to loopback/test-client agent calls only. Remote agents still need `AGENT_SHARED_TOKEN`.
+Do **not** use that as a substitute for real agent auth on a LAN or production deployment.
 
 ### Token/env checklist (what to set, where)
 No new secret tokens were introduced for backup verification or rollout controls.
@@ -250,7 +251,7 @@ Blocked conditions:
 - `DB_AUTO_CREATE_TABLES=true`
 - terminal enabled with `AGENT_TERMINAL_SCHEME=ws` (requires `wss`)
 
-Local dev remains supported with `ALLOW_INSECURE_NO_AGENT_TOKEN=true` and local DB settings.
+Local dev remains supported with `ALLOW_INSECURE_NO_AGENT_TOKEN=true` for loopback/test-client agent calls and local DB settings.
 
 **Server (`deploy/docker/.env`)**
 - `BOOTSTRAP_PASSWORD` (required)

--- a/server/app/app_factory.py
+++ b/server/app/app_factory.py
@@ -107,11 +107,11 @@ def _enforce_non_local_security_guardrails() -> None:
 def _startup() -> None:
     from .config import settings
 
-    # Security guardrail: require AGENT_SHARED_TOKEN unless explicitly running insecure dev mode.
+    # Security guardrail: require AGENT_SHARED_TOKEN unless explicitly running insecure local dev mode.
     if not getattr(settings, "agent_shared_token", None) and not bool(getattr(settings, "allow_insecure_no_agent_token", False)):
         raise RuntimeError(
-            "AGENT_SHARED_TOKEN is required to start the server (agent endpoints would be unauthenticated). "
-            "Set AGENT_SHARED_TOKEN or set ALLOW_INSECURE_NO_AGENT_TOKEN=true for local dev only."
+            "AGENT_SHARED_TOKEN is required to start the server. "
+            "If you intentionally run without it, ALLOW_INSECURE_NO_AGENT_TOKEN only permits loopback/test-client agent calls."
         )
 
     # OIDC config sanity checks (enabled path only)

--- a/server/app/routers/agent.py
+++ b/server/app/routers/agent.py
@@ -12,10 +12,10 @@ from ..dispatcher import dispatcher
 from ..models import Host, HostCVEStatus, HostLoadMetric, HostMetricsSnapshot, HostPackage, HostPackageUpdate, Job, JobRun
 from ..schemas import AgentRegister, JobEvent, PackageUpdatesInventory, PackagesInventory
 from ..services.agents import get_client_ip
-from ..services.agent_auth import require_agent_token
+from ..services.agent_auth import require_agent_token, require_agent_token_dep
 from ..services.db_utils import transaction
 
-router = APIRouter(prefix="/agent", tags=["agent"])
+router = APIRouter(prefix="/agent", tags=["agent"], dependencies=[Depends(require_agent_token_dep)])
 
 
 @router.post("/register")

--- a/server/app/services/agent_auth.py
+++ b/server/app/services/agent_auth.py
@@ -4,11 +4,24 @@ from fastapi import HTTPException, Request
 
 from ..config import settings
 
+_LOOPBACK_HOSTS = {"127.0.0.1", "::1", "localhost", "testclient"}
+
+
+def _request_is_loopback(request: Request) -> bool:
+    host = str(getattr(getattr(request, "client", None), "host", "") or "").strip().lower()
+    return host in _LOOPBACK_HOSTS
+
 
 def require_agent_token(request: Request) -> None:
     expected = getattr(settings, "agent_shared_token", None)
     if not expected:
-        return
+        if bool(getattr(settings, "allow_insecure_no_agent_token", False)) and _request_is_loopback(request):
+            return
+        raise HTTPException(401, "Agent token required")
     got = request.headers.get("X-Fleet-Agent-Token")
     if not got or got != expected:
         raise HTTPException(401, "Invalid agent token")
+
+
+def require_agent_token_dep(request: Request) -> None:
+    require_agent_token(request)

--- a/server/tests/test_agent_auth_hardening.py
+++ b/server/tests/test_agent_auth_hardening.py
@@ -1,0 +1,89 @@
+import importlib
+import sys
+
+from fastapi.routing import APIRoute
+from fastapi.testclient import TestClient
+
+
+def _reload_app_modules():
+    for name in list(sys.modules.keys()):
+        if name == 'app' or name.startswith('app.'):
+            sys.modules.pop(name, None)
+
+
+def _boot_app(monkeypatch, *, insecure_no_token: bool, token: str = ''):
+    monkeypatch.setenv('DATABASE_URL', 'sqlite+pysqlite:///:memory:')
+    monkeypatch.setenv('BOOTSTRAP_PASSWORD', 'admin-password-123')
+    monkeypatch.setenv('UI_COOKIE_SECURE', 'false')
+    monkeypatch.setenv('ALLOW_INSECURE_NO_AGENT_TOKEN', 'true' if insecure_no_token else 'false')
+    monkeypatch.setenv('AGENT_SHARED_TOKEN', token)
+    monkeypatch.setenv('DB_AUTO_CREATE_TABLES', 'true')
+    monkeypatch.setenv('DB_REQUIRE_MIGRATIONS_UP_TO_DATE', 'false')
+    monkeypatch.setenv('MFA_REQUIRE_FOR_PRIVILEGED', 'false')
+    _reload_app_modules()
+    app_factory = importlib.import_module('app.app_factory')
+    return app_factory.create_app()
+
+
+def _register_payload(agent_id='srv-001'):
+    return {
+        'agent_id': agent_id,
+        'hostname': agent_id,
+        'fqdn': f'{agent_id}.example.test',
+        'os_id': 'ubuntu',
+        'os_version': '24.04',
+        'kernel': '6.8.0',
+        'labels': {'env': 'test'},
+    }
+
+
+def test_insecure_no_token_mode_is_loopback_only(monkeypatch):
+    app = _boot_app(monkeypatch, insecure_no_token=True, token='')
+
+    with TestClient(app, client=('192.168.100.50', 12345)) as remote_client:
+        r = remote_client.post('/agent/register', json=_register_payload())
+        assert r.status_code == 401, r.text
+        assert 'Agent token required' in r.text
+
+    with TestClient(app) as loopback_client:
+        r = loopback_client.post('/agent/register', json=_register_payload('srv-local'))
+        assert r.status_code == 200, r.text
+        assert r.json()['ok'] is True
+
+
+def test_agent_routes_require_token_when_configured(monkeypatch):
+    app = _boot_app(monkeypatch, insecure_no_token=False, token='shared-secret-123')
+
+    with TestClient(app, client=('192.168.100.50', 12345)) as client:
+        no_token = client.post('/agent/register', json=_register_payload())
+        assert no_token.status_code == 401, no_token.text
+
+        wrong_token = client.post(
+            '/agent/register',
+            json=_register_payload('srv-wrong'),
+            headers={'X-Fleet-Agent-Token': 'wrong'},
+        )
+        assert wrong_token.status_code == 401, wrong_token.text
+
+        ok = client.post(
+            '/agent/register',
+            json=_register_payload('srv-good'),
+            headers={'X-Fleet-Agent-Token': 'shared-secret-123'},
+        )
+        assert ok.status_code == 200, ok.text
+        assert ok.json()['ok'] is True
+
+
+def test_all_agent_routes_have_router_level_auth_dependency(monkeypatch):
+    app = _boot_app(monkeypatch, insecure_no_token=True, token='')
+    agent_auth = importlib.import_module('app.services.agent_auth')
+
+    agent_routes = [
+        route for route in app.routes
+        if isinstance(route, APIRoute) and route.path.startswith('/agent/')
+    ]
+    assert agent_routes, 'expected at least one /agent route'
+
+    for route in agent_routes:
+        dep_calls = [getattr(dep, 'call', None) for dep in route.dependant.dependencies]
+        assert agent_auth.require_agent_token_dep in dep_calls, f'missing agent auth dependency on {route.path}'


### PR DESCRIPTION
## Summary
- require a token for remote /agent calls even when ALLOW_INSECURE_NO_AGENT_TOKEN is enabled
- restrict insecure no-token mode to loopback/test-client requests only
- enforce agent auth at the /agent router level with a dependency so future routes cannot forget it silently
- update README wording to match the hardened behavior
- add regression coverage for remote rejection, valid-token success, and router-level auth dependency presence

## Notes
- this addresses the high-impact unauthenticated /agent write-path issue from the audit
- it also reduces the future regression risk from relying only on inline require_agent_token calls
- it does not yet replace the shared token model with per-agent credentials; that remains a larger follow-up

## Test Plan
- ./server/.venv/bin/pytest -q server/tests/test_agent_auth_hardening.py server/tests/test_jobs_flow.py -q
