### PR TITLE
Repair legacy host_cve_status schema during migration

### DIFF
--- a/server/alembic/versions/20260420_00_host_cve_search_indexes.py
+++ b/server/alembic/versions/20260420_00_host_cve_search_indexes.py
@@ -1,4 +1,4 @@
-"""add host cve search indexes
+"""repair host cve status schema and add search indexes
 
 Revision ID: 20260420_00
 Revises: 20260419_01
@@ -6,6 +6,7 @@ Create Date: 2026-04-20
 """
 
 from alembic import op
+import sqlalchemy as sa
 
 
 revision = "20260420_00"
@@ -15,6 +16,42 @@ depends_on = None
 
 
 def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    columns = {col["name"] for col in inspector.get_columns("host_cve_status")}
+
+    if "affected" not in columns:
+        op.add_column(
+            "host_cve_status",
+            sa.Column("affected", sa.Boolean(), nullable=False, server_default=sa.text("false")),
+        )
+        if "status" in columns:
+            op.execute(
+                "UPDATE host_cve_status SET affected = CASE "
+                "WHEN lower(coalesce(status, '')) IN ('open', 'affected', 'vulnerable', 'needed', 'unfixed') THEN true "
+                "ELSE false END"
+            )
+        op.alter_column("host_cve_status", "affected", server_default=None)
+
+    if "summary" not in columns:
+        op.add_column("host_cve_status", sa.Column("summary", sa.String(), nullable=True))
+
+    if "checked_at" not in columns:
+        op.add_column(
+            "host_cve_status",
+            sa.Column("checked_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+        )
+        if "updated_at" in columns:
+            op.execute("UPDATE host_cve_status SET checked_at = coalesce(updated_at, checked_at)")
+        elif "first_seen_at" in columns:
+            op.execute("UPDATE host_cve_status SET checked_at = coalesce(first_seen_at, checked_at)")
+        op.alter_column("host_cve_status", "checked_at", server_default=None)
+
+    if "raw" not in columns:
+        op.add_column("host_cve_status", sa.Column("raw", sa.Text(), nullable=True))
+
+    op.execute("CREATE INDEX IF NOT EXISTS ix_host_cve_status_host_id ON host_cve_status (host_id)")
+    op.execute("CREATE INDEX IF NOT EXISTS ix_host_cve_status_checked_at ON host_cve_status (checked_at)")
     op.execute("CREATE INDEX IF NOT EXISTS ix_host_cve_status_cve ON host_cve_status (cve)")
     op.execute("CREATE INDEX IF NOT EXISTS ix_host_cve_status_cve_affected ON host_cve_status (cve, affected)")
 
@@ -22,3 +59,5 @@ def upgrade() -> None:
 def downgrade() -> None:
     op.execute("DROP INDEX IF EXISTS ix_host_cve_status_cve_affected")
     op.execute("DROP INDEX IF EXISTS ix_host_cve_status_cve")
+    op.execute("DROP INDEX IF EXISTS ix_host_cve_status_checked_at")
+    op.execute("DROP INDEX IF EXISTS ix_host_cve_status_host_id")

--- a/server/tests/test_cve_search_performance.py
+++ b/server/tests/test_cve_search_performance.py
@@ -112,9 +112,13 @@ def test_cve_search_filters_visibility_without_full_host_scan_fallback(monkeypat
             ]
 
 
-def test_host_cve_search_index_migration_exists():
+def test_host_cve_search_index_migration_repairs_legacy_schema_before_indexing():
     path = Path(__file__).resolve().parents[1] / 'alembic' / 'versions' / '20260420_00_host_cve_search_indexes.py'
     src = path.read_text()
 
+    assert 'inspector.get_columns("host_cve_status")' in src
+    assert 'if "affected" not in columns:' in src
+    assert 'UPDATE host_cve_status SET affected = CASE' in src
+    assert 'if "checked_at" not in columns:' in src
     assert 'CREATE INDEX IF NOT EXISTS ix_host_cve_status_cve ON host_cve_status (cve)' in src
     assert 'CREATE INDEX IF NOT EXISTS ix_host_cve_status_cve_affected ON host_cve_status (cve, affected)' in src


### PR DESCRIPTION
## Summary
- fix the 20260420_00 migration so it can run against databases created by the earlier incorrect host_cve_status catch-up schema
- repair legacy host_cve_status tables by adding the runtime columns the app actually expects: affected, summary, checked_at, raw
- backfill affected from legacy status values best-effort and checked_at from updated_at/first_seen_at when present
- only then create the new search indexes, preventing the current UndefinedColumn failure on affected
- update the regression test to assert the migration repairs legacy schema before indexing

## Why
The earlier catch-up migration created host_cve_status with columns like status/severity/source, but the runtime model and search route expect affected/summary/checked_at/raw. When alembic tried to create the (cve, affected) index, it failed because affected did not exist.

## Test Plan
- ./server/.venv/bin/pytest -q server/tests/test_cve_search_performance.py
