### PR TITLE
Fix login loop when MFA is pending

### DIFF
--- a/server/app/routers/auth.py
+++ b/server/app/routers/auth.py
@@ -211,6 +211,7 @@ def auth_login(payload: LoginRequest, request: Request, db: Session = Depends(ge
     if require_mfa or has_pending_enroll:
         body["mfa_setup_required"] = bool((require_mfa and not mfa_enabled) or has_pending_enroll)
         body["mfa_required"] = bool(require_mfa and mfa_enabled)
+        body["mfa_redirect"] = "/?mfa=required"
 
     resp = JSONResponse(body)
 

--- a/server/app/templates/index.html
+++ b/server/app/templates/index.html
@@ -4413,27 +4413,35 @@
       catch (e) { console.error('[init failed]', name, e); }
     }
 
-    // Load auth state first so header + MFA flow are not blocked by later init errors.
-    loadAuthInfo().catch((e) => console.error('[loadAuthInfo failed]', e));
+    async function bootUi() {
+      // Load auth state first so header + MFA flow are not blocked by later init errors.
+      await loadAuthInfo();
 
-    safeInit('initHostFilters', initHostFilters);
-    safeInit('initReportsControls', initReportsControls);
-    safeInit('initFleetOverviewControls', initFleetOverviewControls);
-    safeInit('initHostsTableControls', initHostsTableControls);
-    safeInit('initCronjobsControls', initCronjobsControls);
-    safeInit('initSshKeysControls', initSshKeysControls);
-    safeInit('initLoadTimeframeControls', initLoadTimeframeControls);
-    safeInit('initPackagesSearch', initPackagesSearch);
-    safeInit('initAdminPanel', initAdminPanel);
-    safeInit('initOidcMapPreview', initOidcMapPreview);
-    safeInit('initThemeToggle', initThemeToggle);
-    safeInit('initSettingsMenu', initSettingsMenu);
-    safeInit('initHostActionControls', initHostActionControls);
-    safeInit('initHostMetadataEditor', initHostMetadataEditor);
-    safeInit('initAuditDetailModalControls', initAuditDetailModalControls);
-    safeInit('initApprovalDetailModalControls', initApprovalDetailModalControls);
-    safeInit('initFailedRunDetailModalControls', initFailedRunDetailModalControls);
-    safeInit('initApprovalsFilterControls', initApprovalsFilterControls);
+      const mfa = window.__mfa || null;
+      const mfaPending = !!(mfa && (mfa.setup_required || mfa.verify_required));
+      if (mfaPending) return;
+
+      safeInit('initHostFilters', initHostFilters);
+      safeInit('initReportsControls', initReportsControls);
+      safeInit('initFleetOverviewControls', initFleetOverviewControls);
+      safeInit('initHostsTableControls', initHostsTableControls);
+      safeInit('initCronjobsControls', initCronjobsControls);
+      safeInit('initSshKeysControls', initSshKeysControls);
+      safeInit('initLoadTimeframeControls', initLoadTimeframeControls);
+      safeInit('initPackagesSearch', initPackagesSearch);
+      safeInit('initAdminPanel', initAdminPanel);
+      safeInit('initOidcMapPreview', initOidcMapPreview);
+      safeInit('initThemeToggle', initThemeToggle);
+      safeInit('initSettingsMenu', initSettingsMenu);
+      safeInit('initHostActionControls', initHostActionControls);
+      safeInit('initHostMetadataEditor', initHostMetadataEditor);
+      safeInit('initAuditDetailModalControls', initAuditDetailModalControls);
+      safeInit('initApprovalDetailModalControls', initApprovalDetailModalControls);
+      safeInit('initFailedRunDetailModalControls', initFailedRunDetailModalControls);
+      safeInit('initApprovalsFilterControls', initApprovalsFilterControls);
+    }
+
+    bootUi().catch((e) => console.error('[bootUi failed]', e));
     safeInit('bindDiskCardClick', () => {
       const diskCard = document.getElementById('disk-card');
       if (!diskCard) return;

--- a/server/app/templates/login.html
+++ b/server/app/templates/login.html
@@ -137,12 +137,14 @@
         }
         let data = null;
         try { data = await resp.json(); } catch { data = null; }
-        if (data && (data.mfa_required || data.mfa_setup_required)) {
+        const mfaPending = !!(data && (data.mfa_required || data.mfa_setup_required));
+        if (mfaPending) {
           showToast('Signed in. MFA required—complete setup/verification.', 'info', 3500);
         } else {
           showToast('Signed in.', 'success');
         }
-        setTimeout(() => { window.location.href = '/'; }, 400);
+        const nextUrl = (mfaPending && data && data.mfa_redirect) ? data.mfa_redirect : '/';
+        setTimeout(() => { window.location.href = nextUrl; }, 400);
       } catch (e) {
         const msg = e.message || String(e);
         showToast(msg, 'error');


### PR DESCRIPTION
## Summary
- fix the login flow for users who are authenticated but still need to complete MFA
- redirect MFA-pending logins into the MFA flow instead of booting the full dashboard immediately
- stop the main UI bootstrap from firing protected API calls while MFA setup/verification is still pending

## Testing
- . .venv/bin/activate && cd server && PYTHONNOUSERSITE=1 pytest -q tests/test_auth_cookie_secure_behavior.py tests/test_mfa_enroll_start_api.py tests/test_overview_reliability_smoke.py