### PR TITLE
Restore single Alembic head for CVE migrations

### DIFF
--- a/server/alembic/versions/20260505_01_cve_severity_columns.py
+++ b/server/alembic/versions/20260505_01_cve_severity_columns.py
@@ -1,24 +1,23 @@
-"""add cve severity columns
+"""compatibility no-op for duplicate cve severity migration
 
 Revision ID: 20260505_01
-Revises: 20260420_00
+Revises: 20260505_00
 Create Date: 2026-05-05
 """
 
-from alembic import op
-import sqlalchemy as sa
-
 revision = "20260505_01"
-down_revision = "20260420_00"
+down_revision = "20260505_00"
 branch_labels = None
 depends_on = None
 
 
 def upgrade() -> None:
-    op.add_column("cve_definitions", sa.Column("severity", sa.String(), nullable=True))
-    op.add_column("cve_packages", sa.Column("severity", sa.String(), nullable=True))
+    # 20260505_00 already adds these columns.  This revision is kept so any
+    # database that has seen the duplicate revision id remains understandable to
+    # Alembic, while new upgrades have a single linear head.
+    pass
 
 
 def downgrade() -> None:
-    op.drop_column("cve_packages", "severity")
-    op.drop_column("cve_definitions", "severity")
+    # Keep downgrade non-destructive here; dropping belongs to 20260505_00.
+    pass


### PR DESCRIPTION
## Summary
- Restore the Alembic single-head fix after PR #83 merge kept the old duplicate migration contents.
- Make `20260505_01` depend on `20260505_00` and leave it as a compatibility no-op.

## Verification
- `alembic heads` reports only `20260505_01 (head)`.
- `git diff --check` passes.
