### PR TITLE
Handle Ubuntu textual CVE severities

### DIFF
--- a/server/app/services/cve_reporting.py
+++ b/server/app/services/cve_reporting.py
@@ -59,7 +59,17 @@ def _parse_severity(value) -> float | None:
     try:
         return float(value)
     except Exception:
-        return None
+        text = str(value).strip().lower()
+        # Ubuntu OVAL uses textual priorities rather than CVSS numbers.
+        # Map them to stable numeric buckets so UI thresholds still work.
+        priority_scores = {
+            "negligible": 0.1,
+            "low": 3.9,
+            "medium": 6.9,
+            "high": 8.9,
+            "critical": 10.0,
+        }
+        return priority_scores.get(text)
 
 
 def _version_lt(installed: str, fixed: str) -> bool:

--- a/server/app/services/cve_sync.py
+++ b/server/app/services/cve_sync.py
@@ -11,6 +11,24 @@ from datetime import datetime, timezone
 
 logger = logging.getLogger(__name__)
 
+UBUNTU_PRIORITY_SCORES = {
+    "negligible": 0.1,
+    "low": 3.9,
+    "medium": 6.9,
+    "high": 8.9,
+    "critical": 10.0,
+}
+
+
+def parse_ubuntu_severity(value) -> float | None:
+    if value is None:
+        return None
+    try:
+        return float(value)
+    except Exception:
+        return UBUNTU_PRIORITY_SCORES.get(str(value).strip().lower())
+
+
 # Official Ubuntu OVAL definitions
 SUPPORTED_RELEASES = ["focal", "jammy", "noble"]
 OVAL_URL_TEMPLATE = "https://security-metadata.canonical.com/oval/com.ubuntu.{}.cve.oval.xml.bz2"
@@ -205,11 +223,10 @@ def parse_oval_xml(xml_content: bytes, codename: str, master_cve_map: dict):
                         if not text:
                             continue
                         if tag_name.endswith("severity") or ("cvss" in tag_name and "score" in tag_name):
-                            try:
-                                severity = float(text)
+                            parsed_severity = parse_ubuntu_severity(text)
+                            if parsed_severity is not None:
+                                severity = parsed_severity
                                 break
-                            except Exception:
-                                continue
 
                 pkgs_for_cve = {}
                 

--- a/server/tests/test_cve_sync_loop_interval.py
+++ b/server/tests/test_cve_sync_loop_interval.py
@@ -4,3 +4,12 @@ from pathlib import Path
 def test_cve_sync_loop_interval_is_12h():
     src = Path('server/app/services/cve_sync.py').read_text(encoding='utf-8')
     assert 'timeout=43200' in src
+
+
+def test_ubuntu_textual_severity_mapping_is_present():
+    src = Path('server/app/services/cve_sync.py').read_text(encoding='utf-8')
+    assert '"low": 3.9' in src
+    assert '"medium": 6.9' in src
+    assert '"high": 8.9' in src
+    assert '"critical": 10.0' in src
+    assert 'parse_ubuntu_severity(text)' in src


### PR DESCRIPTION
## Summary
- map Ubuntu OVAL textual severities (Low/Medium/High/Critical) to numeric scores during CVE sync
- let report filtering also understand textual severities already present in stored definitions
- add a regression guard for the Ubuntu severity mapping

## Why
Canonical's Ubuntu OVAL feed uses textual priorities, e.g. `High`, instead of numeric CVSS values in the `<severity>` field. The sync code only accepted floats, so CVE severities were stored as `NULL` and the high-severity report filtered them out, even with a very low threshold.

## Testing
- `pytest -q server/tests/test_cve_sync_loop_interval.py server/tests/test_cve_reporting.py`
- `pytest -q server/tests` → 73 passed, 8 warnings
