### PR TITLE
Add package-level CVE HTML report

### DIFF
--- a/server/app/routers/reports.py
+++ b/server/app/routers/reports.py
@@ -11,7 +11,7 @@ from ..config import settings
 from ..db import get_db
 from ..deps import require_ui_user
 from ..models import Host, HostPackageUpdate
-from ..services.cve_reporting import collect_high_severity_findings
+from ..services.cve_reporting import collect_high_severity_findings, merge_findings_by_package
 from ..services.user_scopes import is_host_visible_to_user
 
 router = APIRouter(prefix="/reports", tags=["reports"])
@@ -196,18 +196,19 @@ def cve_high_severity_report(
         raise HTTPException(400, "invalid order (asc|desc)")
 
     findings = collect_high_severity_findings(db, min_severity=float(min_severity))
+    package_findings = merge_findings_by_package(findings)
     visible = []
-    for item in findings:
+    for item in package_findings:
         host = db.execute(select(Host).where(Host.id == item.host_id)).scalar_one_or_none()
         if host and is_host_visible_to_user(db, user, host):
             visible.append(item)
 
     reverse = order == "desc"
     key_map = {
-        "severity": lambda item: (item.severity, item.hostname, item.package_name, item.cve_id),
-        "hostname": lambda item: (item.hostname, item.severity, item.package_name, item.cve_id),
-        "package_name": lambda item: (item.package_name, item.severity, item.hostname, item.cve_id),
-        "cve_id": lambda item: (item.cve_id, item.severity, item.hostname, item.package_name),
+        "severity": lambda item: (item.severity, item.hostname, item.package_name, item.cve_ids[0] if item.cve_ids else ""),
+        "hostname": lambda item: (item.hostname, item.severity, item.package_name, item.cve_ids[0] if item.cve_ids else ""),
+        "package_name": lambda item: (item.package_name, item.severity, item.hostname, item.cve_ids[0] if item.cve_ids else ""),
+        "cve_id": lambda item: (item.cve_ids[0] if item.cve_ids else "", item.severity, item.hostname, item.package_name),
     }
     visible.sort(key=key_map[sort], reverse=reverse)
 
@@ -228,7 +229,9 @@ def cve_high_severity_report(
                 "installed_version": item.installed_version,
                 "candidate_version": item.candidate_version,
                 "fixed_version": item.fixed_version,
-                "cve_id": item.cve_id,
+                "cve_id": item.cve_ids[0] if item.cve_ids else None,
+                "cve_ids": list(item.cve_ids),
+                "cve_count": item.cve_count,
                 "severity": item.severity,
                 "release": item.release,
             }

--- a/server/app/routers/reports_html.py
+++ b/server/app/routers/reports_html.py
@@ -14,6 +14,7 @@ from ..db import get_db
 from ..deps import require_ui_user
 from ..models import Host, HostUser
 from ..routers.reports import hosts_updates_report
+from ..services.cve_reporting import collect_high_severity_findings, merge_findings_by_package
 from ..services.db_utils import transaction
 from ..services.hosts import is_host_online
 from ..services.job_wait import wait_for_job_run
@@ -125,6 +126,97 @@ def hosts_updates_html(
           <th class='num'>{sort_link('All updates','updates')}</th>
           <th>Online</th>
           <th>{sort_link('Last seen','last_seen')}</th>
+        </tr>
+      </thead>
+      <tbody>
+        {body}
+      </tbody>
+    </table>
+  </div>
+</body>
+</html>""",
+        media_type="text/html",
+        headers={"Cache-Control": "no-store"},
+    )
+
+
+@router.get("/cve-high-severity.html", response_class=HTMLResponse)
+def cve_high_severity_html(
+    min_severity: float = 7.0,
+    sort: str = "severity",
+    order: str = "desc",
+    db: Session = Depends(get_db),
+    user=Depends(require_ui_user),
+):
+    findings = collect_high_severity_findings(db, min_severity=float(min_severity))
+    rows = []
+    for item in merge_findings_by_package(findings):
+        host = db.execute(select(Host).where(Host.id == item.host_id)).scalar_one_or_none()
+        if host and is_host_visible_to_user(db, user, host):
+            rows.append(item)
+
+    reverse = (order or "desc").lower() == "desc"
+    key_map = {
+        "severity": lambda item: (item.severity, item.hostname, item.package_name),
+        "hostname": lambda item: (item.hostname, item.severity, item.package_name),
+        "package_name": lambda item: (item.package_name, item.severity, item.hostname),
+    }
+    rows.sort(key=key_map.get(sort, key_map["severity"]), reverse=reverse)
+
+    now = datetime.now(timezone.utc)
+    ts = now.isoformat()
+
+    def esc(s: str) -> str:
+        return (
+            str(s)
+            .replace("&", "&amp;")
+            .replace("<", "&lt;")
+            .replace(">", "&gt;")
+            .replace('"', "&quot;")
+        )
+
+    html_rows = []
+    for r in rows:
+        sev_cls = "critical" if r.severity >= 9.0 else "high"
+        html_rows.append(
+            f"<tr>"
+            f"<td><b>{esc(r.hostname)}</b><div class='report-muted'>{esc(r.agent_id)}</div></td>"
+            f"<td><code class='report-code'>{esc(r.package_name)}</code></td>"
+            f"<td class='num'><span class='report-pill {sev_cls}'>{r.severity:.1f}</span></td>"
+            f"<td><code class='report-code'>{esc(r.installed_version)}</code></td>"
+            f"<td><code class='report-code'>{esc(r.candidate_version or '-')}</code></td>"
+            f"<td><code class='report-code'>{esc(r.fixed_version or '-')}</code></td>"
+            f"<td>{esc(r.release)}</td>"
+            f"<td class='num'>{r.cve_count}</td>"
+            f"</tr>"
+        )
+
+    body = "\n".join(html_rows) if html_rows else "<tr><td colspan='8' class='report-muted'>No affected packages found on online hosts.</td></tr>"
+
+    return HTMLResponse(
+        content=f"""<!doctype html>
+<html>
+<head>
+  <meta charset='utf-8' />
+  <title>Fleet Report - High Severity CVE Packages</title>
+  <link rel='stylesheet' href='/assets/fleet-ui.css' />
+  <script src='/assets/fleet-theme-bootstrap.js'></script>
+</head>
+<body class='fleet-report'>
+  <h1>High Severity CVE Package Report</h1>
+  <div class='report-meta'>Generated: {esc(ts)} UTC • min_severity={esc(str(min_severity))} • rows={len(rows)} • CVEs are merged per host/package for security-team review.</div>
+  <div class='report-wrap'>
+    <table class='report-table'>
+      <thead>
+        <tr>
+          <th>Host</th>
+          <th>Package</th>
+          <th class='num'>Max severity</th>
+          <th>Installed</th>
+          <th>Candidate</th>
+          <th>Fixed version(s)</th>
+          <th>Release</th>
+          <th class='num'>Merged CVEs</th>
         </tr>
       </thead>
       <tbody>

--- a/server/app/services/cve_reporting.py
+++ b/server/app/services/cve_reporting.py
@@ -35,6 +35,24 @@ class SeverityFinding:
     release: str
 
 
+@dataclass(frozen=True)
+class PackageSeverityFinding:
+    host_id: object
+    agent_id: str
+    hostname: str
+    package_name: str
+    installed_version: str
+    candidate_version: str | None
+    severity: float
+    fixed_version: str
+    release: str
+    cve_ids: tuple[str, ...]
+
+    @property
+    def cve_count(self) -> int:
+        return len(self.cve_ids)
+
+
 def _online_cutoff() -> datetime:
     grace = max(5, int(getattr(settings, "agent_online_grace_seconds", 30) or 30))
     return datetime.now(timezone.utc) - timedelta(seconds=grace)
@@ -175,16 +193,47 @@ def collect_high_severity_findings(db: Session, *, min_severity: float = 7.0) ->
     return findings
 
 
+def merge_findings_by_package(findings: list[SeverityFinding]) -> list[PackageSeverityFinding]:
+    grouped: dict[tuple[object, str, str], list[SeverityFinding]] = {}
+    for item in findings:
+        grouped.setdefault((item.host_id, item.release, item.package_name), []).append(item)
+
+    merged: list[PackageSeverityFinding] = []
+    for rows in grouped.values():
+        rows = sorted(rows, key=lambda item: (-item.severity, item.cve_id))
+        top = rows[0]
+        fixed_versions = sorted({item.fixed_version for item in rows if item.fixed_version})
+        merged.append(
+            PackageSeverityFinding(
+                host_id=top.host_id,
+                agent_id=top.agent_id,
+                hostname=top.hostname,
+                package_name=top.package_name,
+                installed_version=top.installed_version,
+                candidate_version=top.candidate_version,
+                severity=max(item.severity for item in rows),
+                fixed_version=", ".join(fixed_versions),
+                release=top.release,
+                cve_ids=tuple(sorted({item.cve_id for item in rows})),
+            )
+        )
+
+    merged.sort(key=lambda item: (-item.severity, item.hostname, item.package_name))
+    return merged
+
+
 def format_report(findings: list[SeverityFinding]) -> str:
     now = datetime.now(timezone.utc)
+    package_findings = merge_findings_by_package(findings)
     lines = [
         f"High severity CVE report generated at {now.isoformat()}",
         f"Threshold: severity > 7",
-        f"Affected findings: {len(findings)}",
+        f"Affected packages: {len(package_findings)}",
+        f"Merged CVEs: {len(findings)}",
         "",
     ]
     current_host = None
-    for item in findings:
+    for item in package_findings:
         if item.hostname != current_host:
             if current_host is not None:
                 lines.append("")
@@ -192,7 +241,7 @@ def format_report(findings: list[SeverityFinding]) -> str:
             lines.append(f"Host: {item.hostname} ({item.agent_id}) [{item.release}]")
         candidate = item.candidate_version or "unknown"
         lines.append(
-            f"- {item.cve_id} severity={item.severity:.1f} package={item.package_name} installed={item.installed_version} candidate={candidate} fixed={item.fixed_version}"
+            f"- package={item.package_name} severity={item.severity:.1f} installed={item.installed_version} candidate={candidate} fixed={item.fixed_version} cve_count={item.cve_count}"
         )
     return "\n".join(lines).rstrip() + "\n"
 

--- a/server/app/templates/fleet-ui.css
+++ b/server/app/templates/fleet-ui.css
@@ -1616,6 +1616,16 @@ body.fleet-report {
   color: var(--report-pill-offline-text);
 }
 
+.fleet-report .report-pill.high {
+  background: rgba(245, 158, 11, 0.18);
+  color: #92400e;
+}
+
+.fleet-report .report-pill.critical {
+  background: rgba(220, 38, 38, 0.16);
+  color: #991b1b;
+}
+
 .empty-state svg {
   width: 64px;
   height: 64px;

--- a/server/app/templates/index.html
+++ b/server/app/templates/index.html
@@ -589,6 +589,7 @@
                 <input id="reports-cve-min-severity" class="host-search" type="number" min="0" max="10" step="0.1" value="7.0" />
               </div>
               <button class="btn btn-primary" id="reports-cve-refresh" type="button">Refresh</button>
+              <button class="btn" id="reports-cve-html" type="button">Open HTML report</button>
               <span id="reports-cve-status" style="color:var(--muted-2);font-size:0.9rem;"></span>
             </div>
             <div style="overflow:auto;">
@@ -596,9 +597,9 @@
                 <thead>
                   <tr>
                     <th>Host</th>
-                    <th>CVE</th>
-                    <th style="text-align:right;">Severity</th>
                     <th>Package</th>
+                    <th style="text-align:right;">Max severity</th>
+                    <th style="text-align:right;">Merged CVEs</th>
                     <th>Installed</th>
                     <th>Candidate</th>
                     <th>Fixed</th>
@@ -4452,9 +4453,9 @@
               const sevCls = sev >= 9 ? 'status-error' : 'status-warn';
               return `<tr>
                 <td><b>${esc(it.hostname || it.agent_id || '')}</b><div class="status-muted">${esc(it.agent_id || '')}</div></td>
-                <td><code>${esc(it.cve_id || '')}</code></td>
-                <td style="text-align:right;"><span class="${sevCls}">${esc(sev.toFixed ? sev.toFixed(1) : sev)}</span></td>
                 <td><code>${esc(it.package_name || '')}</code></td>
+                <td style="text-align:right;"><span class="${sevCls}">${esc(sev.toFixed ? sev.toFixed(1) : sev)}</span></td>
+                <td style="text-align:right;">${esc(it.cve_count || 0)}</td>
                 <td><code>${esc(it.installed_version || '')}</code></td>
                 <td><code>${esc(it.candidate_version || '-')}</code></td>
                 <td><code>${esc(it.fixed_version || '')}</code></td>
@@ -4475,6 +4476,13 @@
       document.getElementById('reports-cve-refresh')?.addEventListener('click', (e) => {
         e.preventDefault();
         void loadHighSeverityCveReport(true);
+      });
+
+      document.getElementById('reports-cve-html')?.addEventListener('click', (e) => {
+        e.preventDefault();
+        const minSeverity = String(document.getElementById('reports-cve-min-severity')?.value || '7.0').trim() || '7.0';
+        const qs = new URLSearchParams({ min_severity: minSeverity, sort: 'severity', order: 'desc' }).toString();
+        window.open(`/reports/cve-high-severity.html?${qs}`, '_blank', 'noopener');
       });
 
       const btn = document.getElementById('reports-user-presence-open');

--- a/server/tests/test_cve_report_api.py
+++ b/server/tests/test_cve_report_api.py
@@ -57,6 +57,7 @@ def test_cve_high_severity_report_api(monkeypatch):
                 )
             )
             db.add(CVEDefinition(cve_id="CVE-2026-9999", definition_data={"severity": 8.8}, severity="8.8"))
+            db.add(CVEDefinition(cve_id="CVE-2026-9998", definition_data={"severity": 9.1}, severity="9.1"))
             db.add(
                 CVEPackage(
                     cve_id="CVE-2026-9999",
@@ -67,13 +68,29 @@ def test_cve_high_severity_report_api(monkeypatch):
                     severity="8.8",
                 )
             )
+            db.add(
+                CVEPackage(
+                    cve_id="CVE-2026-9998",
+                    package_name="openssl",
+                    release="noble",
+                    fixed_version="1.0.3",
+                    status="released",
+                    severity="9.1",
+                )
+            )
             db.commit()
 
         r = client.get("/reports/cve-high-severity?min_severity=7.0&sort=severity&order=desc&limit=50")
         assert r.status_code == 200, r.text
         data = r.json()
         assert data["total"] >= 1
-        item = next((it for it in data["items"] if it["hostname"] == "srv-cve-1" and it["cve_id"] == "CVE-2026-9999"), None)
+        item = next((it for it in data["items"] if it["hostname"] == "srv-cve-1" and it["package_name"] == "openssl"), None)
         assert item is not None
-        assert item["package_name"] == "openssl"
-        assert float(item["severity"]) == 8.8
+        assert item["cve_count"] == 2
+        assert set(item["cve_ids"]) == {"CVE-2026-9998", "CVE-2026-9999"}
+        assert float(item["severity"]) == 9.1
+
+        r = client.get("/reports/cve-high-severity.html?min_severity=7.0")
+        assert r.status_code == 200, r.text
+        assert "High Severity CVE Package Report" in r.text
+        assert "openssl" in r.text

--- a/server/tests/test_cve_reporting.py
+++ b/server/tests/test_cve_reporting.py
@@ -105,7 +105,7 @@ def test_hourly_cve_report_and_patch_cronjob_created(app, monkeypatch):
             assert cron.payload["schedule"]["time_hhmm"] == "03:00"
 
     assert sent["recipient"] == "imre@localhost"
-    assert "CVE-2026-0001" in sent["body"]
+    assert "Affected packages:" in sent["body"]
     assert "package=openssl" in sent["body"]
     assert "srv1" in sent["body"]
 


### PR DESCRIPTION
## Summary
- add `/reports/cve-high-severity.html` as a browser-friendly HTML report for security teams
- merge multiple CVEs into one row per host/package in the UI/API/email report
- keep CVE details available as `cve_ids`/`cve_count`, while making package name the primary report item

## Testing
- `pytest -q server/tests/test_cve_report_api.py server/tests/test_cve_reporting.py`
- `pytest -q server/tests` → 73 passed, 8 warnings
