### PR TITLE
Show CVE links in package report

### DIFF
--- a/server/app/routers/reports_html.py
+++ b/server/app/routers/reports_html.py
@@ -178,10 +178,15 @@ def cve_high_severity_html(
     html_rows = []
     for r in rows:
         sev_cls = "critical" if r.severity >= 9.0 else "high"
+        cve_links = "<br>".join(
+            f"<a href='https://ubuntu.com/security/{esc(cve)}' target='_blank' rel='noopener noreferrer'><code class='report-code'>{esc(cve)}</code></a>"
+            for cve in r.cve_ids
+        ) or "-"
         html_rows.append(
             f"<tr>"
             f"<td><b>{esc(r.hostname)}</b><div class='report-muted'>{esc(r.agent_id)}</div></td>"
             f"<td><code class='report-code'>{esc(r.package_name)}</code></td>"
+            f"<td>{cve_links}</td>"
             f"<td class='num'><span class='report-pill {sev_cls}'>{r.severity:.1f}</span></td>"
             f"<td><code class='report-code'>{esc(r.installed_version)}</code></td>"
             f"<td><code class='report-code'>{esc(r.candidate_version or '-')}</code></td>"
@@ -191,7 +196,7 @@ def cve_high_severity_html(
             f"</tr>"
         )
 
-    body = "\n".join(html_rows) if html_rows else "<tr><td colspan='8' class='report-muted'>No affected packages found on online hosts.</td></tr>"
+    body = "\n".join(html_rows) if html_rows else "<tr><td colspan='9' class='report-muted'>No affected packages found on online hosts.</td></tr>"
 
     return HTMLResponse(
         content=f"""<!doctype html>
@@ -211,6 +216,7 @@ def cve_high_severity_html(
         <tr>
           <th>Host</th>
           <th>Package</th>
+          <th>CVE</th>
           <th class='num'>Max severity</th>
           <th>Installed</th>
           <th>Candidate</th>

--- a/server/app/templates/index.html
+++ b/server/app/templates/index.html
@@ -598,6 +598,7 @@
                   <tr>
                     <th>Host</th>
                     <th>Package</th>
+                    <th>CVE</th>
                     <th style="text-align:right;">Max severity</th>
                     <th style="text-align:right;">Merged CVEs</th>
                     <th>Installed</th>
@@ -4454,6 +4455,7 @@
               return `<tr>
                 <td><b>${esc(it.hostname || it.agent_id || '')}</b><div class="status-muted">${esc(it.agent_id || '')}</div></td>
                 <td><code>${esc(it.package_name || '')}</code></td>
+                <td>${(Array.isArray(it.cve_ids) ? it.cve_ids : []).map((cve) => `<a href="https://ubuntu.com/security/${encodeURIComponent(cve)}" target="_blank" rel="noopener noreferrer"><code>${esc(cve)}</code></a>`).join('<br>') || '-'}</td>
                 <td style="text-align:right;"><span class="${sevCls}">${esc(sev.toFixed ? sev.toFixed(1) : sev)}</span></td>
                 <td style="text-align:right;">${esc(it.cve_count || 0)}</td>
                 <td><code>${esc(it.installed_version || '')}</code></td>

--- a/server/tests/test_cve_report_api.py
+++ b/server/tests/test_cve_report_api.py
@@ -94,3 +94,4 @@ def test_cve_high_severity_report_api(monkeypatch):
         assert r.status_code == 200, r.text
         assert "High Severity CVE Package Report" in r.text
         assert "openssl" in r.text
+        assert "https://ubuntu.com/security/CVE-2026-9998" in r.text


### PR DESCRIPTION
## Summary
- add a CVE column back to the package-level CVE report
- render each CVE as a clickable Ubuntu Security link, e.g. `https://ubuntu.com/security/CVE-2026-9998`
- keep package-level merging so packages with multiple CVEs remain one row, but CVE identifiers are visible for lookup

## Testing
- `pytest -q server/tests/test_cve_report_api.py server/tests/test_cve_reporting.py`
- `pytest -q server/tests` → 73 passed, 8 warnings
