### PR TITLE
Fix Debian CVE version fallback comparison

### DIFF
--- a/server/app/services/cve_reporting.py
+++ b/server/app/services/cve_reporting.py
@@ -9,7 +9,7 @@ from email.message import EmailMessage
 from email.utils import format_datetime
 from zoneinfo import ZoneInfo
 
-from packaging.version import InvalidVersion
+from packaging.version import parse as parse_version
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
@@ -90,6 +90,29 @@ def _parse_severity(value) -> float | None:
         return priority_scores.get(text)
 
 
+def _normalize_debian_version(value: str) -> str:
+    text = str(value or "").strip()
+    if ":" in text:
+        epoch, rest = text.split(":", 1)
+        if epoch.isdigit():
+            text = rest
+    if "-" in text:
+        upstream, revision = text.split("-", 1)
+        text = f"{upstream}+{revision}"
+    return text.replace("ubuntu", ".ubuntu")
+
+
+def _fallback_version_compare(installed: str, fixed: str) -> int:
+    left = _normalize_debian_version(installed)
+    right = _normalize_debian_version(fixed)
+    try:
+        left_v = parse_version(left)
+        right_v = parse_version(right)
+        return (left_v > right_v) - (left_v < right_v)
+    except Exception:
+        return (left > right) - (left < right)
+
+
 def _version_lt(installed: str, fixed: str) -> bool:
     if not installed or not fixed:
         return False
@@ -102,12 +125,7 @@ def _version_lt(installed: str, fixed: str) -> bool:
             pass
         return apt_pkg.version_compare(str(installed), str(fixed)) < 0
     except Exception:
-        try:
-            from packaging.version import Version
-
-            return Version(str(installed)) < Version(str(fixed))
-        except (InvalidVersion, Exception):
-            return str(installed) != str(fixed)
+        return _fallback_version_compare(str(installed), str(fixed)) < 0
 
 
 def _load_cve_severity_map(db: Session, cve_ids: list[str]) -> dict[str, float]:

--- a/server/tests/test_cve_reporting.py
+++ b/server/tests/test_cve_reporting.py
@@ -110,6 +110,23 @@ def test_hourly_cve_report_and_patch_cronjob_created(app, monkeypatch):
     assert "srv1" in sent["body"]
 
 
+def test_version_compare_handles_debian_epoch_when_apt_pkg_unavailable(monkeypatch):
+    import builtins
+    from app.services import cve_reporting
+
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "apt_pkg":
+            raise ImportError("apt_pkg unavailable")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+    assert cve_reporting._version_lt("2.10.1-6ubuntu1.3", "0:2.10.1-6ubuntu1.2") is False
+    assert cve_reporting._version_lt("2.10.1-6ubuntu1.1", "0:2.10.1-6ubuntu1.2") is True
+
+
 def test_hourly_cve_report_skips_offline_hosts(app, monkeypatch):
     from app.db import SessionLocal
     from app.models import CVEDefinition, CVEPackage, Host, HostPackage


### PR DESCRIPTION
## Summary
- fix fallback Debian/Ubuntu version comparison used when `apt_pkg` is unavailable
- normalize Debian epoch prefixes like `0:` before comparing versions
- add a regression test for the observed false positive: installed `2.10.1-6ubuntu1.3` should not be vulnerable to fixed `0:2.10.1-6ubuntu1.2`

## Why
The CVE report could show already-fixed packages when the app container lacks `apt_pkg` and falls back to generic version parsing/string comparison. Ubuntu OVAL fixed versions may include a `0:` epoch, while installed package inventory often omits it.

## Testing
- `pytest -q server/tests/test_cve_reporting.py`
- `pytest -q server/tests` → 74 passed, 8 warnings
