### PR TITLE
Use Debian version rules for CVE vulnerability checks

### DIFF
--- a/server/app/services/cve_reporting.py
+++ b/server/app/services/cve_reporting.py
@@ -9,7 +9,6 @@ from email.message import EmailMessage
 from email.utils import format_datetime
 from zoneinfo import ZoneInfo
 
-from packaging.version import parse as parse_version
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
@@ -90,27 +89,73 @@ def _parse_severity(value) -> float | None:
         return priority_scores.get(text)
 
 
-def _normalize_debian_version(value: str) -> str:
+def _split_debian_version(value: str) -> tuple[int, str, str]:
     text = str(value or "").strip()
+    epoch = 0
     if ":" in text:
-        epoch, rest = text.split(":", 1)
-        if epoch.isdigit():
-            text = rest
+        epoch_text, text = text.split(":", 1)
+        if epoch_text.isdigit():
+            epoch = int(epoch_text)
     if "-" in text:
-        upstream, revision = text.split("-", 1)
-        text = f"{upstream}+{revision}"
-    return text.replace("ubuntu", ".ubuntu")
+        upstream, revision = text.rsplit("-", 1)
+    else:
+        upstream, revision = text, "0"
+    return epoch, upstream, revision
+
+
+def _debian_char_order(ch: str) -> int:
+    if ch == "":
+        return 0
+    if ch == "~":
+        return -1
+    if ch.isalpha():
+        return ord(ch)
+    return ord(ch) + 256
+
+
+def _compare_debian_part(left: str, right: str) -> int:
+    left = str(left or "")
+    right = str(right or "")
+    i = j = 0
+    while i < len(left) or j < len(right):
+        while (i < len(left) and not left[i].isdigit()) or (j < len(right) and not right[j].isdigit()):
+            lch = left[i] if i < len(left) and not left[i].isdigit() else ""
+            rch = right[j] if j < len(right) and not right[j].isdigit() else ""
+            l_order = _debian_char_order(lch)
+            r_order = _debian_char_order(rch)
+            if l_order != r_order:
+                return (l_order > r_order) - (l_order < r_order)
+            if lch:
+                i += 1
+            if rch:
+                j += 1
+
+        l_start = i
+        while i < len(left) and left[i].isdigit():
+            i += 1
+        r_start = j
+        while j < len(right) and right[j].isdigit():
+            j += 1
+
+        l_num = left[l_start:i].lstrip("0") or "0"
+        r_num = right[r_start:j].lstrip("0") or "0"
+        if len(l_num) != len(r_num):
+            return (len(l_num) > len(r_num)) - (len(l_num) < len(r_num))
+        if l_num != r_num:
+            return (l_num > r_num) - (l_num < r_num)
+
+    return 0
 
 
 def _fallback_version_compare(installed: str, fixed: str) -> int:
-    left = _normalize_debian_version(installed)
-    right = _normalize_debian_version(fixed)
-    try:
-        left_v = parse_version(left)
-        right_v = parse_version(right)
-        return (left_v > right_v) - (left_v < right_v)
-    except Exception:
-        return (left > right) - (left < right)
+    left_epoch, left_upstream, left_revision = _split_debian_version(installed)
+    right_epoch, right_upstream, right_revision = _split_debian_version(fixed)
+    if left_epoch != right_epoch:
+        return (left_epoch > right_epoch) - (left_epoch < right_epoch)
+    upstream_cmp = _compare_debian_part(left_upstream, right_upstream)
+    if upstream_cmp:
+        return upstream_cmp
+    return _compare_debian_part(left_revision, right_revision)
 
 
 def _version_lt(installed: str, fixed: str) -> bool:

--- a/server/tests/test_cve_report_api.py
+++ b/server/tests/test_cve_report_api.py
@@ -56,8 +56,19 @@ def test_cve_high_severity_report_api(monkeypatch):
                     checked_at=datetime.now(timezone.utc),
                 )
             )
+            db.add(
+                HostPackage(
+                    host_id=host.id,
+                    name="udisks2",
+                    arch="amd64",
+                    version="2.10.1-6ubuntu1.3",
+                    manager="apt",
+                    collected_at=datetime.now(timezone.utc),
+                )
+            )
             db.add(CVEDefinition(cve_id="CVE-2026-9999", definition_data={"severity": 8.8}, severity="8.8"))
             db.add(CVEDefinition(cve_id="CVE-2026-9998", definition_data={"severity": 9.1}, severity="9.1"))
+            db.add(CVEDefinition(cve_id="CVE-2025-6019", definition_data={"severity": 8.9}, severity="8.9"))
             db.add(
                 CVEPackage(
                     cve_id="CVE-2026-9999",
@@ -78,6 +89,16 @@ def test_cve_high_severity_report_api(monkeypatch):
                     severity="9.1",
                 )
             )
+            db.add(
+                CVEPackage(
+                    cve_id="CVE-2025-6019",
+                    package_name="udisks2",
+                    release="noble",
+                    fixed_version="0:2.10.1-6ubuntu1.2",
+                    status="released",
+                    severity="8.9",
+                )
+            )
             db.commit()
 
         r = client.get("/reports/cve-high-severity?min_severity=7.0&sort=severity&order=desc&limit=50")
@@ -87,6 +108,7 @@ def test_cve_high_severity_report_api(monkeypatch):
         item = next((it for it in data["items"] if it["hostname"] == "srv-cve-1" and it["package_name"] == "openssl"), None)
         assert item is not None
         assert item["cve_count"] == 2
+        assert not any(it["package_name"] == "udisks2" for it in data["items"])
         assert set(item["cve_ids"]) == {"CVE-2026-9998", "CVE-2026-9999"}
         assert float(item["severity"]) == 9.1
 

--- a/server/tests/test_cve_reporting.py
+++ b/server/tests/test_cve_reporting.py
@@ -125,6 +125,9 @@ def test_version_compare_handles_debian_epoch_when_apt_pkg_unavailable(monkeypat
 
     assert cve_reporting._version_lt("2.10.1-6ubuntu1.3", "0:2.10.1-6ubuntu1.2") is False
     assert cve_reporting._version_lt("2.10.1-6ubuntu1.1", "0:2.10.1-6ubuntu1.2") is True
+    assert cve_reporting._version_lt("1:1.0-1", "2:0.1-1") is True
+    assert cve_reporting._version_lt("1.0~rc1-1", "1.0-1") is True
+    assert cve_reporting._version_lt("1.0-1ubuntu10", "1.0-1ubuntu2") is False
 
 
 def test_hourly_cve_report_skips_offline_hosts(app, monkeypatch):


### PR DESCRIPTION
## Summary
- replace the generic fallback version parser with Debian/Ubuntu version comparison rules
- keep the report limited to actually installed packages where installed version is lower than the fixed version
- add regression coverage for the observed `udisks2` false positive: installed `2.10.1-6ubuntu1.3` must not be reported for fixed `0:2.10.1-6ubuntu1.2`

## Why
The package report should only show installed packages that are still vulnerable. Generic version parsing is not reliable for Debian package versions with epochs, revisions, `ubuntuN` suffixes, and `~` pre-release ordering.

## Testing
- `pytest -q server/tests/test_cve_report_api.py server/tests/test_cve_reporting.py`
- `pytest -q server/tests` → 74 passed, 8 warnings
