### PR TITLE
Show whether candidate upgrade fixes CVE

### DIFF
--- a/server/app/routers/reports.py
+++ b/server/app/routers/reports.py
@@ -228,6 +228,7 @@ def cve_high_severity_report(
                 "package_name": item.package_name,
                 "installed_version": item.installed_version,
                 "candidate_version": item.candidate_version,
+                "candidate_fixes": item.candidate_fixes,
                 "fixed_version": item.fixed_version,
                 "cve_id": item.cve_ids[0] if item.cve_ids else None,
                 "cve_ids": list(item.cve_ids),

--- a/server/app/routers/reports_html.py
+++ b/server/app/routers/reports_html.py
@@ -182,6 +182,8 @@ def cve_high_severity_html(
             f"<a href='https://ubuntu.com/security/{esc(cve)}' target='_blank' rel='noopener noreferrer'><code class='report-code'>{esc(cve)}</code></a>"
             for cve in r.cve_ids
         ) or "-"
+        remediation = "Upgrade fixes" if r.candidate_fixes is True else "No fixed candidate" if r.candidate_fixes is False else "Candidate unknown"
+        remediation_cls = "online" if r.candidate_fixes is True else "offline" if r.candidate_fixes is False else "high"
         html_rows.append(
             f"<tr>"
             f"<td><b>{esc(r.hostname)}</b><div class='report-muted'>{esc(r.agent_id)}</div></td>"
@@ -190,13 +192,14 @@ def cve_high_severity_html(
             f"<td class='num'><span class='report-pill {sev_cls}'>{r.severity:.1f}</span></td>"
             f"<td><code class='report-code'>{esc(r.installed_version)}</code></td>"
             f"<td><code class='report-code'>{esc(r.candidate_version or '-')}</code></td>"
+            f"<td><span class='report-pill {remediation_cls}'>{esc(remediation)}</span></td>"
             f"<td><code class='report-code'>{esc(r.fixed_version or '-')}</code></td>"
             f"<td>{esc(r.release)}</td>"
             f"<td class='num'>{r.cve_count}</td>"
             f"</tr>"
         )
 
-    body = "\n".join(html_rows) if html_rows else "<tr><td colspan='9' class='report-muted'>No affected packages found on online hosts.</td></tr>"
+    body = "\n".join(html_rows) if html_rows else "<tr><td colspan='10' class='report-muted'>No affected packages found on online hosts.</td></tr>"
 
     return HTMLResponse(
         content=f"""<!doctype html>
@@ -220,6 +223,7 @@ def cve_high_severity_html(
           <th class='num'>Max severity</th>
           <th>Installed</th>
           <th>Candidate</th>
+          <th>Remediation</th>
           <th>Fixed version(s)</th>
           <th>Release</th>
           <th class='num'>Merged CVEs</th>

--- a/server/app/services/cve_reporting.py
+++ b/server/app/services/cve_reporting.py
@@ -28,6 +28,7 @@ class SeverityFinding:
     package_name: str
     installed_version: str
     candidate_version: str | None
+    candidate_fixes: bool | None
     cve_id: str
     severity: float
     fixed_version: str
@@ -42,6 +43,7 @@ class PackageSeverityFinding:
     package_name: str
     installed_version: str
     candidate_version: str | None
+    candidate_fixes: bool | None
     severity: float
     fixed_version: str
     release: str
@@ -245,6 +247,7 @@ def collect_high_severity_findings(db: Session, *, min_severity: float = 7.0) ->
                         package_name=str(pkg_name),
                         installed_version=str(pkg.version),
                         candidate_version=str(upd.candidate_version) if upd and upd.candidate_version else None,
+                        candidate_fixes=(not _version_lt(str(upd.candidate_version), cve_row.fixed_version)) if upd and upd.candidate_version else None,
                         cve_id=str(cve_row.cve_id),
                         severity=severity,
                         fixed_version=str(cve_row.fixed_version),
@@ -274,6 +277,7 @@ def merge_findings_by_package(findings: list[SeverityFinding]) -> list[PackageSe
                 package_name=top.package_name,
                 installed_version=top.installed_version,
                 candidate_version=top.candidate_version,
+                candidate_fixes=all(item.candidate_fixes is True for item in rows) if top.candidate_version else None,
                 severity=max(item.severity for item in rows),
                 fixed_version=", ".join(fixed_versions),
                 release=top.release,
@@ -303,8 +307,9 @@ def format_report(findings: list[SeverityFinding]) -> str:
             current_host = item.hostname
             lines.append(f"Host: {item.hostname} ({item.agent_id}) [{item.release}]")
         candidate = item.candidate_version or "unknown"
+        remediation = "upgrade fixes" if item.candidate_fixes is True else "no fixed candidate" if item.candidate_fixes is False else "candidate unknown"
         lines.append(
-            f"- package={item.package_name} severity={item.severity:.1f} installed={item.installed_version} candidate={candidate} fixed={item.fixed_version} cve_count={item.cve_count}"
+            f"- package={item.package_name} severity={item.severity:.1f} installed={item.installed_version} candidate={candidate} fixed={item.fixed_version} remediation={remediation} cve_count={item.cve_count}"
         )
     return "\n".join(lines).rstrip() + "\n"
 

--- a/server/app/templates/index.html
+++ b/server/app/templates/index.html
@@ -603,12 +603,13 @@
                     <th style="text-align:right;">Merged CVEs</th>
                     <th>Installed</th>
                     <th>Candidate</th>
+                    <th>Remediation</th>
                     <th>Fixed</th>
                     <th>Release</th>
                   </tr>
                 </thead>
                 <tbody id="reports-cve-table-body">
-                  <tr><td colspan="8" class="status-muted" style="text-align:center;">Press Refresh to load report…</td></tr>
+                  <tr><td colspan="10" class="status-muted" style="text-align:center;">Press Refresh to load report…</td></tr>
                 </tbody>
               </table>
             </div>
@@ -4438,7 +4439,7 @@
         const statusEl = document.getElementById('reports-cve-status');
         const minSeverity = String(document.getElementById('reports-cve-min-severity')?.value || '7.0').trim() || '7.0';
         if (!bodyEl) return;
-        bodyEl.innerHTML = '<tr><td colspan="8" class="status-muted" style="text-align:center;">Loading…</td></tr>';
+        bodyEl.innerHTML = '<tr><td colspan="10" class="status-muted" style="text-align:center;">Loading…</td></tr>';
         if (statusEl) statusEl.textContent = 'Loading…';
         try {
           const qs = new URLSearchParams({ min_severity: minSeverity, sort: 'severity', order: 'desc', limit: '200' }).toString();
@@ -4447,11 +4448,13 @@
           const data = await r.json();
           const items = Array.isArray(data?.items) ? data.items : [];
           if (!items.length) {
-            bodyEl.innerHTML = '<tr><td colspan="8" class="status-ok" style="text-align:center;">No high severity CVEs found on online hosts.</td></tr>';
+            bodyEl.innerHTML = '<tr><td colspan="10" class="status-ok" style="text-align:center;">No high severity CVEs found on online hosts.</td></tr>';
           } else {
             bodyEl.innerHTML = items.map((it) => {
               const sev = Number(it?.severity || 0);
               const sevCls = sev >= 9 ? 'status-error' : 'status-warn';
+              const remediation = it.candidate_fixes === true ? 'Upgrade fixes' : (it.candidate_fixes === false ? 'No fixed candidate' : 'Candidate unknown');
+              const remediationCls = it.candidate_fixes === true ? 'status-ok' : (it.candidate_fixes === false ? 'status-error' : 'status-warn');
               return `<tr>
                 <td><b>${esc(it.hostname || it.agent_id || '')}</b><div class="status-muted">${esc(it.agent_id || '')}</div></td>
                 <td><code>${esc(it.package_name || '')}</code></td>
@@ -4460,6 +4463,7 @@
                 <td style="text-align:right;">${esc(it.cve_count || 0)}</td>
                 <td><code>${esc(it.installed_version || '')}</code></td>
                 <td><code>${esc(it.candidate_version || '-')}</code></td>
+                <td><span class="${remediationCls}">${esc(remediation)}</span></td>
                 <td><code>${esc(it.fixed_version || '')}</code></td>
                 <td>${esc(it.release || '')}</td>
               </tr>`;
@@ -4469,7 +4473,7 @@
           if (showToastOnManual && typeof showToast === 'function') showToast('CVE report refreshed', 'success');
         } catch (e) {
           console.error('[loadHighSeverityCveReport failed]', e);
-          bodyEl.innerHTML = '<tr><td colspan="8" class="status-error" style="text-align:center;">Failed to load CVE report.</td></tr>';
+          bodyEl.innerHTML = '<tr><td colspan="10" class="status-error" style="text-align:center;">Failed to load CVE report.</td></tr>';
           if (statusEl) statusEl.textContent = 'Load failed';
           if (showToastOnManual && typeof showToast === 'function') showToast('Failed to load CVE report', 'error');
         }

--- a/server/tests/test_cve_report_api.py
+++ b/server/tests/test_cve_report_api.py
@@ -108,6 +108,7 @@ def test_cve_high_severity_report_api(monkeypatch):
         item = next((it for it in data["items"] if it["hostname"] == "srv-cve-1" and it["package_name"] == "openssl"), None)
         assert item is not None
         assert item["cve_count"] == 2
+        assert item["candidate_fixes"] is True
         assert not any(it["package_name"] == "udisks2" for it in data["items"])
         assert set(item["cve_ids"]) == {"CVE-2026-9998", "CVE-2026-9999"}
         assert float(item["severity"]) == 9.1
@@ -116,4 +117,5 @@ def test_cve_high_severity_report_api(monkeypatch):
         assert r.status_code == 200, r.text
         assert "High Severity CVE Package Report" in r.text
         assert "openssl" in r.text
+        assert "Upgrade fixes" in r.text
         assert "https://ubuntu.com/security/CVE-2026-9998" in r.text


### PR DESCRIPTION
## Summary
- add a Remediation column to the high-severity CVE package report
- show `Upgrade fixes` when the host's available candidate version is at or above every fixed version for the merged CVEs
- expose the same result in the JSON API as `candidate_fixes`

## Why
Rows like installed `2.10.1-6build1`, candidate `2.10.1-6ubuntu1.3`, fixed `0:2.10.1-6ubuntu1.2` should explicitly tell the operator that installing the candidate package will resolve the CVE.

## Testing
- `pytest -q server/tests/test_cve_report_api.py server/tests/test_cve_reporting.py`
- `pytest -q server/tests` → 74 passed, 8 warnings
