### PR TITLE
Promote service management navigation

### DIFF
--- a/server/app/templates/fleet-phase3-overview.js
+++ b/server/app/templates/fleet-phase3-overview.js
@@ -1008,6 +1008,7 @@
     const navOverview = document.getElementById('nav-overview');
     const navHosts = document.getElementById('nav-hosts');
     const navUserManagement = document.getElementById('nav-user-management');
+    const navServiceManagement = document.getElementById('nav-service-management');
     const navCronjobs = document.getElementById('nav-cronjobs');
     const navSshKeys = document.getElementById('nav-sshkeys');
     const navReports = document.getElementById('nav-reports');
@@ -1130,6 +1131,14 @@
       if (containerEl) containerEl.classList.add('sidebar-collapsed');
     }
 
+    function showServiceManagementTab() {
+      ctx.stopMetricsPolling();
+      ctx.clearCurrentHostSelection();
+      document.querySelectorAll('.tab-content-custom, .tab-content').forEach(c => c.classList.remove('active'));
+      document.getElementById('service-management-tab')?.classList.add('active');
+      if (containerEl) containerEl.classList.add('sidebar-collapsed');
+    }
+
     function showSshKeysTab() {
       ctx.clearCurrentHostSelection();
       document.querySelectorAll('.tab-content-custom, .tab-content').forEach(c => c.classList.remove('active'));
@@ -1151,6 +1160,7 @@
     navOverview?.addEventListener('click', (e) => { e.preventDefault(); showOverviewTab(); });
     navHosts?.addEventListener('click', (e) => { e.preventDefault(); showHostsTab(); });
     navUserManagement?.addEventListener('click', (e) => { e.preventDefault(); showUserManagementTab(); });
+    navServiceManagement?.addEventListener('click', (e) => { e.preventDefault(); showServiceManagementTab(); });
     navCronjobs?.addEventListener('click', (e) => { e.preventDefault(); showCronjobsTab(); });
     navSshKeys?.addEventListener('click', (e) => { e.preventDefault(); showSshKeysTab(); });
     navReports?.addEventListener('click', (e) => { e.preventDefault(); showReportsTab(); });

--- a/server/app/templates/index.html
+++ b/server/app/templates/index.html
@@ -75,6 +75,7 @@
         <button class="btn" id="nav-overview" type="button">Dashboard <span id="notifications-badge" class="nav-indicator error" style="display:none;">•</span><span id="approvals-badge" title="Pending high-risk approvals" class="nav-indicator warn" style="display:none;">⚠</span></button>
         <button class="btn" id="nav-hosts" type="button">Hosts</button>
         <button class="btn" id="nav-user-management" type="button">User management</button>
+        <button class="btn" id="nav-service-management" type="button">Service management</button>
         <button class="btn" id="nav-sshkeys" type="button">Security <span id="sshkeys-approval-indicator" title="Pending approvals" class="nav-indicator error" style="display:none;">!</span></button>
         <button class="btn" id="nav-cronjobs" type="button">Automation</button>
         <button class="btn" id="nav-reports" type="button">Reports</button>
@@ -611,8 +612,16 @@
           </div>
         </div>
 
+      </div>
+    </div>
+
+    <div class="tab-content-custom" id="service-management-tab">
+      <div class="admin-content">
+        <div class="section-title">Service management</div>
+        <div class="admin-note" style="margin-bottom:0.75rem;">Find a system service across visible online servers and stop or disable it on selected hosts.</div>
+
         <div class="admin-card" style="margin-bottom:1rem;">
-          <div class="admin-card-title">Service management</div>
+          <div class="admin-card-title">Find service</div>
           <div class="admin-card-body" style="display:grid;gap:0.75rem;">
             <div style="display:flex;gap:.6rem;flex-wrap:wrap;align-items:flex-end;">
               <div style="min-width:260px;">

--- a/server/tests/frontend/service-management-navigation.test.js
+++ b/server/tests/frontend/service-management-navigation.test.js
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+describe('service management navigation', () => {
+  const root = path.resolve(path.dirname(new URL(import.meta.url).pathname), '../../..');
+  const indexPath = path.join(root, 'server/app/templates/index.html');
+  const overviewPath = path.join(root, 'server/app/templates/fleet-phase3-overview.js');
+  const indexSrc = fs.readFileSync(indexPath, 'utf8');
+  const overviewSrc = fs.readFileSync(overviewPath, 'utf8');
+
+  it('renders service management as a top-level sidebar destination', () => {
+    expect(indexSrc).toContain('id="nav-service-management"');
+    expect(indexSrc).toContain('id="service-management-tab"');
+    expect(overviewSrc).toContain("const navServiceManagement = document.getElementById('nav-service-management')");
+    expect(overviewSrc).toContain("document.getElementById('service-management-tab')?.classList.add('active')");
+    expect(overviewSrc).toContain('navServiceManagement?.addEventListener');
+  });
+
+  it('does not render service management inside user management', () => {
+    const userTabStart = indexSrc.indexOf('id="user-management-tab"');
+    const serviceTabStart = indexSrc.indexOf('id="service-management-tab"');
+    expect(userTabStart).toBeGreaterThanOrEqual(0);
+    expect(serviceTabStart).toBeGreaterThan(userTabStart);
+
+    const userTabMarkup = indexSrc.slice(userTabStart, serviceTabStart);
+    expect(userTabMarkup).toContain('<div class="section-title">User management</div>');
+    expect(userTabMarkup).not.toContain('Service management');
+    expect(userTabMarkup).not.toContain('service-management-name');
+  });
+});


### PR DESCRIPTION
## Summary
- add Service management as a top-level sidebar destination
- move the service management panel out of the User management tab
- stop/disable matching systemd socket units for socket-activated services like ssh, so disabled ssh.socket cannot keep port 22 open
- add frontend and Go regression tests

## Tests
- npm run test:frontend
- go test ./... (from agent/)