### PR TITLE
Make CVE background jobs startup-resilient

### DIFF
--- a/server/app/services/cve_reporting.py
+++ b/server/app/services/cve_reporting.py
@@ -397,11 +397,15 @@ def run_hourly_report_once(db: Session, *, min_severity: float = 7.0, recipient:
         return {"sent": False, "finding_count": 0, "cronjob_id": cron_id}
 
     body = format_report(findings)
-    send_report_via_smtp(
-        recipient=recipient,
-        subject=f"High severity CVE report ({len(findings)} findings)",
-        body=body,
-    )
+    try:
+        send_report_via_smtp(
+            recipient=recipient,
+            subject=f"High severity CVE report ({len(findings)} findings)",
+            body=body,
+        )
+    except (OSError, smtplib.SMTPException) as exc:
+        logger.warning("High severity CVE report email skipped: SMTP unavailable: %s", exc)
+        return {"sent": False, "finding_count": len(findings), "cronjob_id": cron_id, "email_error": str(exc)}
     return {"sent": True, "finding_count": len(findings), "cronjob_id": cron_id}
 
 

--- a/server/app/services/cve_sync.py
+++ b/server/app/services/cve_sync.py
@@ -32,11 +32,13 @@ def parse_ubuntu_severity(value) -> float | None:
 # Official Ubuntu OVAL definitions
 SUPPORTED_RELEASES = ["focal", "jammy", "noble"]
 OVAL_URL_TEMPLATE = "https://security-metadata.canonical.com/oval/com.ubuntu.{}.cve.oval.xml.bz2"
+CVE_SYNC_HTTP_TIMEOUT_SECONDS = 30
 
 async def sync_cve_definitions(db: AsyncSession):
     master_cve_map = {}
 
-    async with aiohttp.ClientSession() as session:
+    timeout = aiohttp.ClientTimeout(total=CVE_SYNC_HTTP_TIMEOUT_SECONDS)
+    async with aiohttp.ClientSession(timeout=timeout) as session:
         for codename in SUPPORTED_RELEASES:
             url = OVAL_URL_TEMPLATE.format(codename)
             logger.info(f"Downloading OVAL data for {codename} from {url}...")

--- a/server/tests/test_cve_reporting.py
+++ b/server/tests/test_cve_reporting.py
@@ -130,6 +130,39 @@ def test_version_compare_handles_debian_epoch_when_apt_pkg_unavailable(monkeypat
     assert cve_reporting._version_lt("1.0-1ubuntu10", "1.0-1ubuntu2") is False
 
 
+def test_hourly_cve_report_tolerates_smtp_unavailable(monkeypatch):
+    from app.services import cve_reporting
+
+    finding = cve_reporting.SeverityFinding(
+        host_id="host-1",
+        agent_id="agent-1",
+        hostname="srv1",
+        package_name="openssl",
+        installed_version="1.0.0",
+        candidate_version="1.0.2",
+        candidate_fixes=True,
+        cve_id="CVE-2026-0001",
+        severity=8.4,
+        fixed_version="1.0.2",
+        release="noble",
+    )
+
+    monkeypatch.setattr(cve_reporting, "collect_high_severity_findings", lambda db, min_severity=7.0: [finding])
+    monkeypatch.setattr(cve_reporting, "ensure_patch_cronjob", lambda db, findings: "cron-1")
+
+    def smtp_refused(*, recipient: str, subject: str, body: str):
+        raise ConnectionRefusedError(111, "Connection refused")
+
+    monkeypatch.setattr(cve_reporting, "send_report_via_smtp", smtp_refused)
+
+    result = cve_reporting.run_hourly_report_once(object())
+
+    assert result["sent"] is False
+    assert result["finding_count"] == 1
+    assert result["cronjob_id"] == "cron-1"
+    assert "Connection refused" in result["email_error"]
+
+
 def test_hourly_cve_report_skips_offline_hosts(app, monkeypatch):
     from app.db import SessionLocal
     from app.models import CVEDefinition, CVEPackage, Host, HostPackage

--- a/server/tests/test_cve_sync_loop_interval.py
+++ b/server/tests/test_cve_sync_loop_interval.py
@@ -13,3 +13,10 @@ def test_ubuntu_textual_severity_mapping_is_present():
     assert '"high": 8.9' in src
     assert '"critical": 10.0' in src
     assert 'parse_ubuntu_severity(text)' in src
+
+
+def test_cve_sync_uses_bounded_http_timeout():
+    src = Path('server/app/services/cve_sync.py').read_text(encoding='utf-8')
+    assert 'CVE_SYNC_HTTP_TIMEOUT_SECONDS = 30' in src
+    assert 'aiohttp.ClientTimeout(total=CVE_SYNC_HTTP_TIMEOUT_SECONDS)' in src
+    assert 'aiohttp.ClientSession(timeout=timeout)' in src


### PR DESCRIPTION
## Summary
- bound Ubuntu OVAL download attempts with an aiohttp total timeout so unreachable Canonical metadata cannot hang CVE sync indefinitely
- treat local SMTP refusal as a best-effort email skip instead of raising a reporting tick exception
- keep cronjob scheduling/report calculation behavior intact when email delivery is unavailable
- add regression tests for SMTP refusal and bounded CVE sync HTTP timeouts

## Tests
- .venv/bin/pytest server/tests/test_cve_reporting.py server/tests/test_cve_sync_loop_interval.py
- npm run test:frontend