### PR TITLE
Show socket-activated services as enabled

### DIFF
--- a/agent/cmd/fleet-agent/main.go
+++ b/agent/cmd/fleet-agent/main.go
@@ -1718,15 +1718,9 @@ func queryServices(ctx context.Context) (string, string, int, string) {
 
 	// Check enabled state for each service
 	for name, svc := range serviceMap {
-		// Check if service is enabled using systemctl is-enabled
-		enabledCmd := exec.CommandContext(queryCtx, "systemctl", "is-enabled", name+".service")
-		enabledOut, err := enabledCmd.Output()
-		svc.Enabled = false
-		if err == nil {
-			enabledState := strings.TrimSpace(string(enabledOut))
-			svc.Enabled = isEnabledState(enabledState)
-		}
-		// If command fails (e.g., service not found), Enabled remains false
+		svc.Enabled = serviceInventoryEnabled(name, func(unitName string) bool {
+			return isSystemdUnitEnabled(queryCtx, unitName)
+		})
 	}
 
 	// Convert map to slice
@@ -1753,6 +1747,21 @@ func isEnabledState(state string) bool {
 	default:
 		return false
 	}
+}
+
+func isSystemdUnitEnabled(ctx context.Context, unitName string) bool {
+	enabledCmd := exec.CommandContext(ctx, "systemctl", "is-enabled", unitName)
+	enabledOut, err := enabledCmd.Output()
+	if err != nil {
+		return false
+	}
+	return isEnabledState(strings.TrimSpace(string(enabledOut)))
+}
+
+func serviceInventoryEnabled(serviceName string, checkUnitEnabled func(string) bool) bool {
+	serviceUnit := normalizeServiceUnit(serviceName)
+	socketUnit := serviceSocketUnit(serviceUnit)
+	return checkUnitEnabled(serviceUnit) || checkUnitEnabled(socketUnit)
 }
 
 func querySystemMetrics(ctx context.Context) (string, string, int, string) {

--- a/agent/cmd/fleet-agent/main_test.go
+++ b/agent/cmd/fleet-agent/main_test.go
@@ -105,3 +105,24 @@ func TestServiceControlCommandsWithoutSocketKeepsOrdinaryServiceBehavior(t *test
 		t.Fatalf("stop commands = %#v, want %#v", got, want)
 	}
 }
+
+func TestServiceInventoryEnabledTreatsSocketEnabledAsEnabled(t *testing.T) {
+	enabledUnits := map[string]bool{
+		"ssh.service": false,
+		"ssh.socket":  true,
+	}
+
+	if !serviceInventoryEnabled("ssh", func(unitName string) bool {
+		return enabledUnits[unitName]
+	}) {
+		t.Fatal("ssh inventory enabled = false, want true when ssh.socket is enabled")
+	}
+}
+
+func TestServiceInventoryEnabledFalseWhenServiceAndSocketDisabled(t *testing.T) {
+	if serviceInventoryEnabled("ssh", func(unitName string) bool {
+		return false
+	}) {
+		t.Fatal("ssh inventory enabled = true, want false when service and socket are disabled")
+	}
+}


### PR DESCRIPTION
## Summary
- make service inventory check both <service>.service and matching <service>.socket enablement
- report services like ssh as autostart-enabled when ssh.socket is enabled, even if ssh.service itself is disabled
- clarify UI wording: runtime state remains Status, boot/socket enablement is now shown as Autostart
- add Go and frontend regression tests

## Verified
- k8s-25171 currently has ssh.service active/disabled and ssh.socket inactive/disabled after a manual tty1 start, so login works because the service is active, not because it is enabled
- k8s-3031 and k8s-6144 had ssh.service active/disabled and ssh.socket active/enabled, which explains active disabled in the old UI

## Tests
- go test ./... (from agent/)
- npm run test:frontend