### PR TITLE
Clarify service autostart status

### DIFF
--- a/server/app/templates/fleet-phase3-host-workflows.js
+++ b/server/app/templates/fleet-phase3-host-workflows.js
@@ -106,7 +106,7 @@
 
       servicesList.innerHTML = data.services.map(service => {
         const statusClass = service.status === 'active' ? 'active' : service.status === 'failed' ? 'failed' : 'inactive';
-        const enabledBadge = service.enabled ? '<span class="sudo-badge yes" style="margin-left: 0.5rem;">✓ Enabled</span>' : '<span class="sudo-badge no" style="margin-left: 0.5rem;">✗ Disabled</span>';
+        const enabledBadge = service.enabled ? '<span class="sudo-badge yes" style="margin-left: 0.5rem;">✓ Autostart</span>' : '<span class="sudo-badge no" style="margin-left: 0.5rem;">✗ Manual start</span>';
         return `
             <div class="service-card" data-service-name="${w.escapeHtml(service.name)}">
               <div class="service-info">

--- a/server/app/templates/index.html
+++ b/server/app/templates/index.html
@@ -645,7 +645,7 @@
                     <th>Host</th>
                     <th>Service</th>
                     <th>Status</th>
-                    <th>Enabled</th>
+                    <th>Autostart</th>
                     <th>Description</th>
                     <th>Last seen</th>
                   </tr>
@@ -4882,7 +4882,7 @@
             <td><b>${esc(it.hostname || agentId)}</b><div class="status-muted">${esc(agentId)}${it.ip_address ? ` • ${esc(it.ip_address)}` : ''}${osName ? ` • ${esc(osName)}` : ''}</div></td>
             <td><code>${esc(it.service_name || '')}</code></td>
             <td><span class="${statusCls}">${esc(status || '-')}</span></td>
-            <td><span class="${it.enabled ? 'status-warn' : 'status-muted'}">${it.enabled ? 'enabled' : 'disabled'}</span></td>
+            <td><span class="${it.enabled ? 'status-warn' : 'status-muted'}">${it.enabled ? 'yes' : 'manual'}</span></td>
             <td>${esc(it.description || '-')}</td>
             <td class="status-muted">${esc(it.last_seen || '')}</td>
           </tr>`;

--- a/server/tests/frontend/service-management-navigation.test.js
+++ b/server/tests/frontend/service-management-navigation.test.js
@@ -6,8 +6,10 @@ describe('service management navigation', () => {
   const root = path.resolve(path.dirname(new URL(import.meta.url).pathname), '../../..');
   const indexPath = path.join(root, 'server/app/templates/index.html');
   const overviewPath = path.join(root, 'server/app/templates/fleet-phase3-overview.js');
+  const hostWorkflowsPath = path.join(root, 'server/app/templates/fleet-phase3-host-workflows.js');
   const indexSrc = fs.readFileSync(indexPath, 'utf8');
   const overviewSrc = fs.readFileSync(overviewPath, 'utf8');
+  const hostWorkflowsSrc = fs.readFileSync(hostWorkflowsPath, 'utf8');
 
   it('renders service management as a top-level sidebar destination', () => {
     expect(indexSrc).toContain('id="nav-service-management"');
@@ -27,5 +29,13 @@ describe('service management navigation', () => {
     expect(userTabMarkup).toContain('<div class="section-title">User management</div>');
     expect(userTabMarkup).not.toContain('Service management');
     expect(userTabMarkup).not.toContain('service-management-name');
+  });
+
+  it('labels service enablement as autostart instead of current access', () => {
+    expect(indexSrc).toContain('<th>Autostart</th>');
+    expect(indexSrc).not.toContain('<th>Enabled</th>');
+    expect(indexSrc).toContain("${it.enabled ? 'yes' : 'manual'}");
+    expect(hostWorkflowsSrc).toContain('✓ Autostart');
+    expect(hostWorkflowsSrc).toContain('✗ Manual start');
   });
 });


### PR DESCRIPTION
## Summary
- rename service enablement display to Autostart so it is not confused with current reachability
- show fleet-wide service rows as Autostart yes/manual
- show host service badges as Autostart/Manual start
- extend frontend regression coverage for the new wording

## Context
For ssh active/disabled, login works because ssh.service is currently active. Disabled only means it will not autostart through that unit. The UI should make that distinction clear.

## Tests
- npm run test:frontend