### PR TITLE
Fix local Docker compose startup defaults

### DIFF
--- a/deploy/docker/docker-compose.yml
+++ b/deploy/docker/docker-compose.yml
@@ -48,6 +48,9 @@ services:
 
       # Agent auth tokens (set in .env; do NOT commit real values)
       AGENT_SHARED_TOKEN: ${AGENT_SHARED_TOKEN:-}
+      # Local compose defaults use placeholder/dev settings. Set false in production
+      # after replacing placeholders and enabling HTTPS/migration guardrails.
+      ALLOW_INSECURE_NO_AGENT_TOKEN: ${ALLOW_INSECURE_NO_AGENT_TOKEN:-true}
       # High-risk feature: only enable if agent has FLEET_TERMINAL_TOKEN set too
       AGENT_TERMINAL_TOKEN: ${AGENT_TERMINAL_TOKEN:-}
       # For production behind HTTPS, set AGENT_TERMINAL_SCHEME=wss

--- a/deploy/docker/env.example
+++ b/deploy/docker/env.example
@@ -39,6 +39,9 @@ ADMIN_ENABLE_MIGRATIONS_ENDPOINT=false
 
 # Agent auth tokens (shared secret MVP)
 AGENT_SHARED_TOKEN=change-me-agent-token
+# Local Docker Compose default. Set false for production after replacing placeholder secrets
+# and enabling HTTPS/migration guardrails.
+ALLOW_INSECURE_NO_AGENT_TOKEN=true
 # Terminal proxy token (server-side). Must match the agent-side token (FLEET_TERMINAL_TOKEN).
 AGENT_TERMINAL_TOKEN=change-me-terminal-token
 # Use wss in production when running behind HTTPS reverse proxy.

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -2,6 +2,7 @@ fastapi==0.135.1
 starlette==1.0.1
 uvicorn[standard]==0.30.1
 sqlalchemy==2.0.31
+greenlet==3.1.1
 psycopg[binary]==3.2.13
 pydantic==2.8.2
 pydantic-settings==2.3.4

--- a/server/tests/test_startup_guardrails.py
+++ b/server/tests/test_startup_guardrails.py
@@ -1,4 +1,5 @@
 import importlib
+from pathlib import Path
 
 
 def test_explicit_insecure_dev_mode_treats_compose_db_host_as_local(monkeypatch):
@@ -19,3 +20,10 @@ def test_non_local_when_insecure_override_is_disabled(monkeypatch):
     monkeypatch.setattr(config_mod.settings, "database_url", "postgresql+psycopg://fleet:fleet@db:5432/fleet")
 
     assert app_factory._is_non_local_deployment() is True
+
+
+def test_docker_compose_defaults_opt_into_local_dev_mode():
+    root = Path(__file__).resolve().parents[2]
+    for rel_path in ("deploy/docker/docker-compose.yml", "deploy/docker/env.example"):
+        content = (root / rel_path).read_text(encoding="utf-8")
+        assert "ALLOW_INSECURE_NO_AGENT_TOKEN" in content


### PR DESCRIPTION
## Summary
- pass ALLOW_INSECURE_NO_AGENT_TOKEN=true by default for local Docker Compose so placeholder/dev env values do not trigger production guardrail startup failure
- document the same local compose default in deploy/docker/env.example
- add greenlet runtime dependency required by SQLAlchemy async sessions used by CVE sync
- add a startup guardrail regression for compose/env examples

## Root Cause
The bundled compose/env defaults are local-dev placeholders, but without ALLOW_INSECURE_NO_AGENT_TOKEN the app treats DATABASE_URL host db as non-local and blocks startup on placeholder secrets, UI_COOKIE_SECURE=false, DB_AUTO_CREATE_TABLES=true, and ws terminal scheme.

## Verification
- docker compose -f deploy/docker/docker-compose.yml config shows ALLOW_INSECURE_NO_AGENT_TOKEN=true
- startup reproduction with deploy/docker/env.example + SQLite reaches /health 200
- .venv/bin/pytest server/tests/test_startup_guardrails.py
- .venv/bin/pytest server/tests/test_cve_reporting.py server/tests/test_cve_sync_loop_interval.py
- npm run test:frontend

Note: running startup guardrail and CVE tests in one pytest process still hits the repo's existing settings-cache ordering issue, so they were run separately.