### PR TITLE
Add bulk enable action to service management

### DIFF
--- a/server/app/routers/reports.py
+++ b/server/app/routers/reports.py
@@ -606,8 +606,8 @@ async def service_presence_action(
         raise HTTPException(403, "Insufficient permissions to manage services")
 
     action_norm = (action or "").strip().lower()
-    if action_norm not in ("stop", "disable"):
-        raise HTTPException(400, "Invalid action. Must be stop or disable.")
+    if action_norm not in ("stop", "disable", "enable"):
+        raise HTTPException(400, "Invalid action. Must be stop, disable, or enable.")
 
     service_name = (payload.service_name or "").strip()
     if not service_name:

--- a/server/app/templates/index.html
+++ b/server/app/templates/index.html
@@ -618,7 +618,7 @@
     <div class="tab-content-custom" id="service-management-tab">
       <div class="admin-content">
         <div class="section-title">Service management</div>
-        <div class="admin-note" style="margin-bottom:0.75rem;">Find a system service across visible online servers and stop or disable it on selected hosts.</div>
+        <div class="admin-note" style="margin-bottom:0.75rem;">Find a system service across visible online servers and start, stop, enable, or disable it on selected hosts.</div>
 
         <div class="admin-card" style="margin-bottom:1rem;">
           <div class="admin-card-title">Find service</div>
@@ -633,6 +633,7 @@
               </label>
               <button class="btn btn-primary" id="service-management-search" type="button">Find</button>
               <button class="btn" id="service-management-select-all" type="button">Select all</button>
+              <button class="btn btn-success" id="service-management-enable" type="button">Enable selected</button>
               <button class="btn btn-warning" id="service-management-stop" type="button">Stop selected</button>
               <button class="btn btn-danger" id="service-management-stop-disable" type="button">Stop & disable selected</button>
               <span id="service-management-status" style="color:var(--muted-2);font-size:0.9rem;"></span>
@@ -4831,6 +4832,7 @@
       const searchBtn = document.getElementById('service-management-search');
       const selectAllBtn = document.getElementById('service-management-select-all');
       const checkAllEl = document.getElementById('service-management-check-all');
+      const enableBtn = document.getElementById('service-management-enable');
       const stopBtn = document.getElementById('service-management-stop');
       const stopDisableBtn = document.getElementById('service-management-stop-disable');
       const statusEl = document.getElementById('service-management-status');
@@ -4854,7 +4856,7 @@
         const canManageServices = !!currentPermissions?.can_manage_services;
         const selected = selectedServiceAgentIds();
         const disabled = !canManageServices || selected.length === 0;
-        [stopBtn, stopDisableBtn].forEach((btn) => {
+        [enableBtn, stopBtn, stopDisableBtn].forEach((btn) => {
           if (!btn) return;
           btn.disabled = disabled;
           btn.title = canManageServices ? '' : 'Service management permission required';
@@ -4974,11 +4976,24 @@
           if (typeof showToast === 'function') showToast('Select at least one matching host', 'error');
           return;
         }
-        const label = kind === 'stop-disable' ? 'Stop and disable' : 'Stop';
+        const label = kind === 'stop-disable' ? 'Stop and disable' : kind === 'enable' ? 'Enable' : 'Stop';
         if (!confirm(`${label} ${serviceName} on ${agentIds.length} selected host(s)?`)) return;
 
-        [stopBtn, stopDisableBtn, searchBtn].forEach((btn) => { if (btn) btn.disabled = true; });
+        [enableBtn, stopBtn, stopDisableBtn, searchBtn].forEach((btn) => { if (btn) btn.disabled = true; });
         try {
+          if (kind === 'enable') {
+            if (statusEl) statusEl.textContent = 'Queueing enable job…';
+            const enableData = await queueServiceAction('enable', agentIds);
+            if (statusEl) statusEl.textContent = `Enable job ${enableData.job_id} queued for ${enableData.targets?.length || 0} host(s)…`;
+            const enableSummary = await waitForJobDone(enableData.job_id);
+            if (statusEl) statusEl.textContent = enableSummary.done
+              ? `Enabled: ${enableSummary.success.length} succeeded, ${enableSummary.failed.length} failed. Refreshing…`
+              : 'Enable still running. Refreshing visible status…';
+            if (typeof showToast === 'function') showToast('Enable job finished', 'success');
+            await searchServices(false);
+            return;
+          }
+
           if (statusEl) statusEl.textContent = 'Queueing stop job…';
           const stopData = await queueServiceAction('stop', agentIds);
           if (statusEl) statusEl.textContent = `Stop job ${stopData.job_id} queued for ${stopData.targets?.length || 0} host(s)…`;
@@ -5034,6 +5049,10 @@
           if (!cb.disabled) cb.checked = checked;
         });
         updateServiceActionState();
+      });
+      enableBtn?.addEventListener('click', (e) => {
+        e.preventDefault();
+        void runServiceOperation('enable');
       });
       stopBtn?.addEventListener('click', (e) => {
         e.preventDefault();

--- a/server/tests/frontend/service-management-navigation.test.js
+++ b/server/tests/frontend/service-management-navigation.test.js
@@ -38,4 +38,11 @@ describe('service management navigation', () => {
     expect(hostWorkflowsSrc).toContain('✓ Autostart');
     expect(hostWorkflowsSrc).toContain('✗ Manual start');
   });
+
+  it('supports bulk enabling selected service matches', () => {
+    expect(indexSrc).toContain('id="service-management-enable"');
+    expect(indexSrc).toContain('Enable selected');
+    expect(indexSrc).toContain("void runServiceOperation('enable')");
+    expect(indexSrc).toContain("await queueServiceAction('enable', agentIds)");
+  });
 });

--- a/server/tests/test_user_presence_management_api.py
+++ b/server/tests/test_user_presence_management_api.py
@@ -160,3 +160,21 @@ def test_service_presence_action_targets_online_selected_hosts(monkeypatch):
             assert job.payload["action"] == "stop"
             runs = db.execute(select(JobRun).where(JobRun.job_id == job.id)).scalars().all()
             assert [run.agent_id for run in runs] == ["srv-online"]
+
+        enable = client.post(
+            "/reports/service-presence/enable",
+            json={"service_name": "nginx", "agent_ids": ["srv-online", "srv-offline"]},
+            headers=headers,
+        )
+        assert enable.status_code == 200, enable.text
+        out = enable.json()
+        assert out["targets"] == ["srv-online"]
+        assert out["skipped_offline"] == ["srv-offline"]
+
+        with SessionLocal() as db:
+            job = db.execute(select(Job).where(Job.job_key == out["job_id"])).scalar_one()
+            assert job.job_type == "service-control"
+            assert job.payload["service_name"] == "nginx"
+            assert job.payload["action"] == "enable"
+            runs = db.execute(select(JobRun).where(JobRun.job_id == job.id)).scalars().all()
+            assert [run.agent_id for run in runs] == ["srv-online"]


### PR DESCRIPTION
## Summary
- add an `Enable selected` action to the fleet Service management panel
- allow `/reports/service-presence/enable` to queue bulk service-control jobs
- cover the new UI affordance and API action in tests

## Testing
- `npm run test:frontend -- server/tests/frontend/service-management-navigation.test.js`
- `PYTHONPATH=server .venv/bin/pytest server/tests/test_user_presence_management_api.py -q`
- `git diff --check`
