### PR TITLE
Wait for systemd service start results

### DIFF
--- a/agent/cmd/fleet-agent/main.go
+++ b/agent/cmd/fleet-agent/main.go
@@ -2065,8 +2065,7 @@ func serviceControlCommands(serviceUnit, action string, socketExists bool) ([][]
 	socketUnit := serviceSocketUnit(serviceUnit)
 	switch action {
 	case "start":
-		// Use --no-block to prevent systemctl from waiting for service to fully start.
-		return [][]string{{"start", "--no-block", serviceUnit}}, nil
+		return [][]string{{"start", serviceUnit}}, nil
 	case "stop":
 		commands := make([][]string, 0, 2)
 		if socketExists {
@@ -2075,8 +2074,7 @@ func serviceControlCommands(serviceUnit, action string, socketExists bool) ([][]
 		commands = append(commands, []string{"stop", serviceUnit})
 		return commands, nil
 	case "restart":
-		// Use --no-block to prevent systemctl from waiting for service to fully restart.
-		return [][]string{{"restart", "--no-block", serviceUnit}}, nil
+		return [][]string{{"restart", serviceUnit}}, nil
 	case "enable":
 		return [][]string{{"enable", serviceUnit}}, nil
 	case "disable":

--- a/agent/cmd/fleet-agent/main_test.go
+++ b/agent/cmd/fleet-agent/main_test.go
@@ -106,6 +106,28 @@ func TestServiceControlCommandsWithoutSocketKeepsOrdinaryServiceBehavior(t *test
 	}
 }
 
+func TestServiceControlCommandsStartWaitsForSystemdResult(t *testing.T) {
+	got, err := serviceControlCommands("unattended-upgrades.service", "start", false)
+	if err != nil {
+		t.Fatalf("serviceControlCommands returned error: %v", err)
+	}
+	want := [][]string{{"start", "unattended-upgrades.service"}}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("start commands = %#v, want %#v", got, want)
+	}
+}
+
+func TestServiceControlCommandsRestartWaitsForSystemdResult(t *testing.T) {
+	got, err := serviceControlCommands("nginx.service", "restart", false)
+	if err != nil {
+		t.Fatalf("serviceControlCommands returned error: %v", err)
+	}
+	want := [][]string{{"restart", "nginx.service"}}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("restart commands = %#v, want %#v", got, want)
+	}
+}
+
 func TestServiceInventoryEnabledTreatsSocketEnabledAsEnabled(t *testing.T) {
 	enabledUnits := map[string]bool{
 		"ssh.service": false,

--- a/server/app/templates/fleet-phase3-host-workflows.js
+++ b/server/app/templates/fleet-phase3-host-workflows.js
@@ -244,7 +244,7 @@
       const actionLabel = action === 'start' ? 'Started' : action === 'stop' ? 'Stopped' : action === 'restart' ? 'Restarted' : action === 'enable' ? 'Enabled' : action === 'disable' ? 'Disabled' : action;
       w.showToast(`${actionLabel} ${serviceName}`, 'success');
       await new Promise(resolve => setTimeout(resolve, 1000));
-      await waitForServicesToStabilize(ctx, agentId, serviceName);
+      await loadServices(ctx, agentId);
     } catch (error) {
       console.error('Error controlling service:', error);
       if (targetCard) {

--- a/server/tests/frontend/service-management-navigation.test.js
+++ b/server/tests/frontend/service-management-navigation.test.js
@@ -45,4 +45,8 @@ describe('service management navigation', () => {
     expect(indexSrc).toContain("void runServiceOperation('enable')");
     expect(indexSrc).toContain("await queueServiceAction('enable', agentIds)");
   });
+
+  it('refreshes service state after a completed per-host service action', () => {
+    expect(hostWorkflowsSrc).toMatch(/w\.showToast\(`\$\{actionLabel\} \$\{serviceName\}`, 'success'\);[\s\S]*await loadServices\(ctx, agentId\);/);
+  });
 });


### PR DESCRIPTION
## Summary
- make the agent wait for systemd `start` and `restart` job results instead of using `--no-block`
- refresh per-host Services immediately after a completed control action instead of waiting for inactive services to become active
- add coverage for start/restart command generation and the frontend refresh path

## Why
Short-lived or special services such as `unattended-upgrades` can remain `inactive` after a manual start attempt. With `--no-block`, the UI could report success before systemd had actually completed or failed the job, then poll for an `active` state that may never be correct.

## Testing
- `go test ./cmd/fleet-agent`
- `npm run test:frontend -- server/tests/frontend/service-management-navigation.test.js`
- `git diff --check origin/main..HEAD`
