### PR TITLE
Fix dashboard alert endpoints

### DIFF
--- a/server/app/app_factory.py
+++ b/server/app/app_factory.py
@@ -15,7 +15,7 @@ from fastapi.staticfiles import StaticFiles
 
 from .db import Base, SessionLocal, engine
 from .deps import get_current_user_from_request
-from .routers import agent, ansible, approvals, audit, auth, backup_verification, cronjobs, dashboard, hosts, jobs, migrations, mfa, patching, reports, reports_html, search, sshkeys, terminal_ws, ui
+from .routers import agent, ansible, approvals, audit, auth, backup_verification, cronjobs, dashboard, hosts, jobs, maintenance_windows, migrations, mfa, patching, reports, reports_html, search, sshkeys, terminal_ws, ui
 
 logger = logging.getLogger(__name__)
 
@@ -522,6 +522,7 @@ def create_app() -> FastAPI:
     app.include_router(reports_html.router)
     app.include_router(jobs.router)
     app.include_router(ansible.router)
+    app.include_router(maintenance_windows.router)
     from .config import settings
     if bool(getattr(settings, "admin_enable_migrations_endpoint", False)):
         app.include_router(migrations.router)

--- a/server/app/routers/dashboard.py
+++ b/server/app/routers/dashboard.py
@@ -814,10 +814,14 @@ def dashboard_notifications(db: Session = Depends(get_db), user=Depends(require_
 
         allowed: list[dict] = []
         cooldown_cutoff = now - timedelta(seconds=cooldown_s)
+        emitted_keys: set[str] = set()
         for it in candidates:
             key = str(it.get("dedupe_key") or "")
             if not key:
                 allowed.append(it)
+                continue
+            if key in emitted_keys:
+                suppressed += 1
                 continue
             st = state_map.get(key)
             if st and st.last_emitted_at:
@@ -828,6 +832,7 @@ def dashboard_notifications(db: Session = Depends(get_db), user=Depends(require_
                     suppressed += 1
                     continue
             allowed.append(it)
+            emitted_keys.add(key)
 
         items = allowed[:limit]
 
@@ -844,15 +849,15 @@ def dashboard_notifications(db: Session = Depends(get_db), user=Depends(require_
                         st.kind = str(it.get("kind") or "")
                         st.severity = str(it.get("severity") or "")
                     else:
-                        db.add(
-                            NotificationDedupeState(
-                                dedupe_key=key,
-                                kind=str(it.get("kind") or ""),
-                                severity=str(it.get("severity") or ""),
-                                last_emitted_at=now,
-                                last_title=str(it.get("title") or ""),
-                            )
+                        st = NotificationDedupeState(
+                            dedupe_key=key,
+                            kind=str(it.get("kind") or ""),
+                            severity=str(it.get("severity") or ""),
+                            last_emitted_at=now,
+                            last_title=str(it.get("title") or ""),
                         )
+                        db.add(st)
+                        state_map[key] = st
 
         for it in items:
             it.pop("dedupe_key", None)

--- a/server/app/routers/maintenance_windows.py
+++ b/server/app/routers/maintenance_windows.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from fastapi import APIRouter, Depends
+
+from ..config import settings
+from ..deps import require_ui_user
+from ..services.maintenance import is_action_guarded, is_within_maintenance_window
+
+router = APIRouter(prefix="/maintenance-windows", tags=["maintenance-windows"])
+
+
+@router.post("/evaluate")
+def evaluate_maintenance_window(payload: dict, user=Depends(require_ui_user)):
+    action = str((payload or {}).get("action") or "").strip().lower()
+    agent_ids = [str(a).strip() for a in ((payload or {}).get("agent_ids") or []) if str(a).strip()]
+    enabled = bool(getattr(settings, "maintenance_window_enabled", False))
+    guarded = is_action_guarded(action)
+    within = bool(is_within_maintenance_window())
+    timezone_name = str(getattr(settings, "maintenance_window_timezone", "UTC") or "UTC")
+    start = str(getattr(settings, "maintenance_window_start_hhmm", "01:00") or "01:00")
+    end = str(getattr(settings, "maintenance_window_end_hhmm", "05:00") or "05:00")
+
+    matched_windows = []
+    if enabled and guarded:
+        matched_windows.append({
+            "name": "Configured maintenance window",
+            "timezone": timezone_name,
+            "start": start,
+            "end": end,
+            "agent_count": len(agent_ids),
+        })
+
+    blocked = bool(enabled and guarded and not within)
+    return {
+        "decision": "block" if blocked else "allow",
+        "action": action,
+        "enabled": enabled,
+        "guarded": guarded,
+        "within_window_now": within,
+        "matched_windows": matched_windows if blocked else [],
+        "ts": datetime.now(timezone.utc).isoformat(),
+    }

--- a/server/tests/test_maintenance_window_guardrails.py
+++ b/server/tests/test_maintenance_window_guardrails.py
@@ -80,3 +80,40 @@ def test_guardrails_block_security_campaign_outside_window(monkeypatch):
         )
         assert r.status_code == 403, r.text
         assert "maintenance window" in r.text.lower()
+
+
+def test_maintenance_window_evaluate_endpoint_reports_block(monkeypatch):
+    monkeypatch.setenv("DATABASE_URL", "sqlite+pysqlite:///:memory:")
+    monkeypatch.setenv("BOOTSTRAP_USERNAME", "admin")
+    monkeypatch.setenv("BOOTSTRAP_PASSWORD", "admin-password-123")
+    monkeypatch.setenv("MFA_REQUIRE_FOR_PRIVILEGED", "false")
+    monkeypatch.setenv("ALLOW_INSECURE_NO_AGENT_TOKEN", "true")
+    monkeypatch.setenv("MAINTENANCE_WINDOW_ENABLED", "true")
+    monkeypatch.setenv("MAINTENANCE_WINDOW_TIMEZONE", "UTC")
+    monkeypatch.setenv("MAINTENANCE_WINDOW_START_HHMM", _future_hhmm(2))
+    monkeypatch.setenv("MAINTENANCE_WINDOW_END_HHMM", _future_hhmm(3))
+    monkeypatch.setenv("MAINTENANCE_WINDOW_GUARDED_ACTIONS", "dist-upgrade,security-campaign")
+
+    _reload_app_modules()
+    app_factory = importlib.import_module("app.app_factory")
+    app = app_factory.create_app()
+
+    from fastapi.testclient import TestClient
+
+    with TestClient(app) as client:
+        lr = client.post("/auth/login", json={"username": "admin", "password": "admin-password-123"})
+        assert lr.status_code == 200, lr.text
+        csrf = client.cookies.get("fleet_csrf")
+        headers = {"X-CSRF-Token": csrf} if csrf else {}
+
+        r = client.post(
+            "/maintenance-windows/evaluate",
+            json={"action": "security-campaign", "agent_ids": ["srv-001"]},
+            headers=headers,
+        )
+        assert r.status_code == 200, r.text
+        data = r.json()
+        assert data["decision"] == "block"
+        assert data["guarded"] is True
+        assert data["within_window_now"] is False
+        assert data["matched_windows"]

--- a/server/tests/test_notifications_dedupe_cooldown.py
+++ b/server/tests/test_notifications_dedupe_cooldown.py
@@ -132,3 +132,66 @@ def test_notifications_dedupe_state_endpoint_admin_only(monkeypatch):
 
         denied = viewer_client.get("/dashboard/notifications/dedupe-state?minutes=1440")
         assert denied.status_code == 403, denied.text
+
+
+def test_notifications_dedupe_duplicate_failed_runs_do_not_insert_duplicate_state(monkeypatch):
+    monkeypatch.setenv("DATABASE_URL", "sqlite+pysqlite:///:memory:")
+    monkeypatch.setenv("BOOTSTRAP_USERNAME", "admin")
+    monkeypatch.setenv("BOOTSTRAP_PASSWORD", "admin-password-123")
+    monkeypatch.setenv("MFA_REQUIRE_FOR_PRIVILEGED", "false")
+    monkeypatch.setenv("ALLOW_INSECURE_NO_AGENT_TOKEN", "true")
+    monkeypatch.setenv("NOTIFICATIONS_DEDUPE_ENABLED", "true")
+    monkeypatch.setenv("NOTIFICATIONS_DEDUPE_COOLDOWN_SECONDS", "3600")
+
+    _reload_app_modules()
+    app_factory = importlib.import_module("app.app_factory")
+    app = app_factory.create_app()
+
+    from app.db import SessionLocal
+    from app.models import Host, Job, JobRun, NotificationDedupeState
+    from fastapi.testclient import TestClient
+
+    with TestClient(app) as client:
+        rr = client.post(
+            "/agent/register",
+            json={
+                "agent_id": "srv-failed-01",
+                "hostname": "srv-failed-01",
+                "fqdn": None,
+                "os_id": "ubuntu",
+                "os_version": "24.04",
+                "kernel": "test",
+                "labels": {"env": "test"},
+            },
+        )
+        assert rr.status_code == 200, rr.text
+
+        with SessionLocal() as db:
+            h = db.execute(select(Host).where(Host.agent_id == "srv-failed-01")).scalar_one()
+            h.last_seen = datetime.now(timezone.utc)
+            for idx in range(2):
+                job = Job(job_key=f"failed-job-{idx}", created_by="test", job_type="pkg-upgrade", payload={}, selector={})
+                db.add(job)
+                db.flush()
+                db.add(JobRun(
+                    job_id=job.id,
+                    agent_id="srv-failed-01",
+                    status="failed",
+                    finished_at=datetime.now(timezone.utc) - timedelta(minutes=idx + 1),
+                    exit_code=1,
+                ))
+            db.commit()
+
+        lr = client.post("/auth/login", json={"username": "admin", "password": "admin-password-123"})
+        assert lr.status_code == 200, lr.text
+
+        r = client.get("/dashboard/notifications?limit=8")
+        assert r.status_code == 200, r.text
+        data = r.json()
+        failed_items = [it for it in data.get("items", []) if it.get("kind") == "failed_run"]
+        assert len(failed_items) == 1, data
+        assert int(data.get("suppressed") or 0) >= 1
+
+        with SessionLocal() as db:
+            rows = db.execute(select(NotificationDedupeState).where(NotificationDedupeState.dedupe_key == "failed_run:srv-failed-01:pkg-upgrade")).scalars().all()
+            assert len(rows) == 1


### PR DESCRIPTION
## Summary
- prevent `/dashboard/notifications` from inserting duplicate notification dedupe rows when several candidates share a dedupe key
- add the missing `/maintenance-windows/evaluate` endpoint used by the dashboard guard controls
- add regression coverage for duplicate failed-run notifications and maintenance-window evaluation

## Why
The Active alerts tab can fail with a 500 when multiple failed runs for the same host/job type share one dedupe key and the request tries to create duplicate dedupe state rows. The dashboard also calls `/maintenance-windows/evaluate`, but that route was not registered.

## Testing
- `PYTHONPATH=server .venv/bin/pytest server/tests/test_notifications_dedupe_cooldown.py server/tests/test_maintenance_window_guardrails.py server/tests/test_overview_reliability_smoke.py -q`
- `python3 -m py_compile server/app/routers/maintenance_windows.py server/app/routers/dashboard.py server/app/app_factory.py server/tests/test_notifications_dedupe_cooldown.py server/tests/test_maintenance_window_guardrails.py`
- `git diff --check`
