### PR TITLE
Add fleet service start action

### DIFF
--- a/server/app/routers/reports.py
+++ b/server/app/routers/reports.py
@@ -606,8 +606,8 @@ async def service_presence_action(
         raise HTTPException(403, "Insufficient permissions to manage services")
 
     action_norm = (action or "").strip().lower()
-    if action_norm not in ("stop", "disable", "enable"):
-        raise HTTPException(400, "Invalid action. Must be stop, disable, or enable.")
+    if action_norm not in ("start", "stop", "disable", "enable"):
+        raise HTTPException(400, "Invalid action. Must be start, stop, disable, or enable.")
 
     service_name = (payload.service_name or "").strip()
     if not service_name:

--- a/server/app/templates/index.html
+++ b/server/app/templates/index.html
@@ -633,6 +633,7 @@
               </label>
               <button class="btn btn-primary" id="service-management-search" type="button">Find</button>
               <button class="btn" id="service-management-select-all" type="button">Select all</button>
+              <button class="btn btn-success" id="service-management-start" type="button">Start selected</button>
               <button class="btn btn-success" id="service-management-enable" type="button">Enable selected</button>
               <button class="btn btn-warning" id="service-management-stop" type="button">Stop selected</button>
               <button class="btn btn-danger" id="service-management-stop-disable" type="button">Stop & disable selected</button>
@@ -4832,6 +4833,7 @@
       const searchBtn = document.getElementById('service-management-search');
       const selectAllBtn = document.getElementById('service-management-select-all');
       const checkAllEl = document.getElementById('service-management-check-all');
+      const startBtn = document.getElementById('service-management-start');
       const enableBtn = document.getElementById('service-management-enable');
       const stopBtn = document.getElementById('service-management-stop');
       const stopDisableBtn = document.getElementById('service-management-stop-disable');
@@ -4856,7 +4858,7 @@
         const canManageServices = !!currentPermissions?.can_manage_services;
         const selected = selectedServiceAgentIds();
         const disabled = !canManageServices || selected.length === 0;
-        [enableBtn, stopBtn, stopDisableBtn].forEach((btn) => {
+        [startBtn, enableBtn, stopBtn, stopDisableBtn].forEach((btn) => {
           if (!btn) return;
           btn.disabled = disabled;
           btn.title = canManageServices ? '' : 'Service management permission required';
@@ -4976,11 +4978,24 @@
           if (typeof showToast === 'function') showToast('Select at least one matching host', 'error');
           return;
         }
-        const label = kind === 'stop-disable' ? 'Stop and disable' : kind === 'enable' ? 'Enable' : 'Stop';
+        const label = kind === 'stop-disable' ? 'Stop and disable' : kind === 'enable' ? 'Enable' : kind === 'start' ? 'Start' : 'Stop';
         if (!confirm(`${label} ${serviceName} on ${agentIds.length} selected host(s)?`)) return;
 
-        [enableBtn, stopBtn, stopDisableBtn, searchBtn].forEach((btn) => { if (btn) btn.disabled = true; });
+        [startBtn, enableBtn, stopBtn, stopDisableBtn, searchBtn].forEach((btn) => { if (btn) btn.disabled = true; });
         try {
+          if (kind === 'start') {
+            if (statusEl) statusEl.textContent = 'Queueing start job…';
+            const startData = await queueServiceAction('start', agentIds);
+            if (statusEl) statusEl.textContent = `Start job ${startData.job_id} queued for ${startData.targets?.length || 0} host(s)…`;
+            const startSummary = await waitForJobDone(startData.job_id);
+            if (statusEl) statusEl.textContent = startSummary.done
+              ? `Started: ${startSummary.success.length} succeeded, ${startSummary.failed.length} failed. Refreshing…`
+              : 'Start still running. Refreshing visible status…';
+            if (typeof showToast === 'function') showToast('Start job finished', 'success');
+            await searchServices(false);
+            return;
+          }
+
           if (kind === 'enable') {
             if (statusEl) statusEl.textContent = 'Queueing enable job…';
             const enableData = await queueServiceAction('enable', agentIds);
@@ -5049,6 +5064,10 @@
           if (!cb.disabled) cb.checked = checked;
         });
         updateServiceActionState();
+      });
+      startBtn?.addEventListener('click', (e) => {
+        e.preventDefault();
+        void runServiceOperation('start');
       });
       enableBtn?.addEventListener('click', (e) => {
         e.preventDefault();

--- a/server/tests/frontend/service-management-navigation.test.js
+++ b/server/tests/frontend/service-management-navigation.test.js
@@ -40,6 +40,10 @@ describe('service management navigation', () => {
   });
 
   it('supports bulk enabling selected service matches', () => {
+    expect(indexSrc).toContain('id="service-management-start"');
+    expect(indexSrc).toContain('Start selected');
+    expect(indexSrc).toContain("void runServiceOperation('start')");
+    expect(indexSrc).toContain("await queueServiceAction('start', agentIds)");
     expect(indexSrc).toContain('id="service-management-enable"');
     expect(indexSrc).toContain('Enable selected');
     expect(indexSrc).toContain("void runServiceOperation('enable')");

--- a/server/tests/test_user_presence_management_api.py
+++ b/server/tests/test_user_presence_management_api.py
@@ -178,3 +178,21 @@ def test_service_presence_action_targets_online_selected_hosts(monkeypatch):
             assert job.payload["action"] == "enable"
             runs = db.execute(select(JobRun).where(JobRun.job_id == job.id)).scalars().all()
             assert [run.agent_id for run in runs] == ["srv-online"]
+
+        start = client.post(
+            "/reports/service-presence/start",
+            json={"service_name": "nginx", "agent_ids": ["srv-online", "srv-offline"]},
+            headers=headers,
+        )
+        assert start.status_code == 200, start.text
+        out = start.json()
+        assert out["targets"] == ["srv-online"]
+        assert out["skipped_offline"] == ["srv-offline"]
+
+        with SessionLocal() as db:
+            job = db.execute(select(Job).where(Job.job_key == out["job_id"])).scalar_one()
+            assert job.job_type == "service-control"
+            assert job.payload["service_name"] == "nginx"
+            assert job.payload["action"] == "start"
+            runs = db.execute(select(JobRun).where(JobRun.job_id == job.id)).scalars().all()
+            assert [run.agent_id for run in runs] == ["srv-online"]


### PR DESCRIPTION
## Summary
- add `Start selected` to the fleet-wide Service management panel
- allow `/reports/service-presence/start` to queue bulk service-control jobs
- cover the new UI action and backend route in tests

## Why
Per-host System Services could start a service, but the top-level Service management panel did not expose or allow the matching bulk start action.

## Testing
- `npm run test:frontend -- server/tests/frontend/service-management-navigation.test.js`
- `PYTHONPATH=server .venv/bin/pytest server/tests/test_user_presence_management_api.py -q`
- `python3 -m py_compile server/app/routers/reports.py server/tests/test_user_presence_management_api.py`
- `git diff --check`
