### PR TITLE
Refresh CVE state after package upgrades

### DIFF
--- a/server/app/routers/agent.py
+++ b/server/app/routers/agent.py
@@ -14,6 +14,7 @@ from ..schemas import AgentRegister, JobEvent, PackageUpdatesInventory, Packages
 from ..services.agents import get_client_ip
 from ..services.agent_auth import require_agent_token, require_agent_token_dep
 from ..services.db_utils import transaction
+from ..services.jobs import create_job_with_runs
 
 router = APIRouter(prefix="/agent", tags=["agent"], dependencies=[Depends(require_agent_token_dep)])
 
@@ -288,6 +289,42 @@ def agent_job_event(payload: JobEvent, request: Request, db: Session = Depends(g
                 db.rollback()
             except Exception:
                 pass
+
+    # Package upgrades change installed versions and may resolve CVEs. Invalidate stale
+    # host CVE results immediately and queue inventory so package snapshots catch up.
+    if payload.status == "success" and job.job_type in ("pkg-upgrade", "pkg-install", "pkg-reinstall", "dist-upgrade"):
+        try:
+            with db.begin_nested():
+                host = db.execute(select(Host).where(Host.agent_id == payload.agent_id)).scalar_one_or_none()
+                if host:
+                    db.execute(delete(HostCVEStatus).where(HostCVEStatus.host_id == host.id))
+
+                    # Avoid enqueueing duplicate refreshes if one is already pending/running for this host.
+                    existing_refresh = (
+                        db.execute(
+                            select(JobRun)
+                            .join(Job, Job.id == JobRun.job_id)
+                            .where(
+                                Job.job_type == "inventory-now",
+                                JobRun.agent_id == payload.agent_id,
+                                JobRun.status.in_(("queued", "running")),
+                            )
+                            .limit(1)
+                        )
+                        .scalar_one_or_none()
+                    )
+                    if not existing_refresh:
+                        create_job_with_runs(
+                            db=db,
+                            job_type="inventory-now",
+                            payload={"reason": f"post-{job.job_type}", "source_job_id": job.job_key},
+                            agent_ids=[payload.agent_id],
+                            commit=False,
+                            created_by=job.created_by,
+                        )
+        except Exception:
+            # best-effort cache invalidation/refresh scheduling
+            pass
 
     # Persist package update availability cache when an update-check job completes
     if payload.status == "success" and job.job_type == "query-pkg-updates" and payload.stdout:

--- a/server/app/routers/jobs.py
+++ b/server/app/routers/jobs.py
@@ -224,7 +224,7 @@ async def create_pkg_upgrade(payload: JobCreatePkgUpgrade, request: Request, db:
             commit=False,
         )
 
-    async def build(aid: str):
+    def build(aid: str):
         # Prefer per-agent packages if provided; fall back to global packages.
         pkgs = (packages_by_agent.get(aid) or packages) or []
         return {"job_id": created.job_key, "type": "pkg-upgrade", "packages": pkgs}

--- a/server/app/templates/fleet-phase3-host-filters-vuln.js
+++ b/server/app/templates/fleet-phase3-host-filters-vuln.js
@@ -409,6 +409,36 @@
       }
     }
 
+    async function refreshHostInventoryCache(targets, statusNode) {
+      const ids = Array.isArray(targets) ? targets.filter(Boolean) : [];
+      if (!ids.length) return;
+      const doWait = ids.length <= 20;
+
+      if (statusNode) {
+        statusNode.textContent = doWait
+          ? 'Refreshing package inventory after upgrade…'
+          : 'Queueing package inventory refresh after upgrade…';
+      }
+
+      const resp = await fetch('/jobs/inventory-now', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ agent_ids: ids })
+      });
+      if (!resp.ok) {
+        let msg = resp.statusText;
+        try { const err = await resp.json(); msg = err.detail || err.message || msg; } catch (_) { }
+        throw new Error(msg);
+      }
+      const out = await resp.json();
+      const jobId = out.job_id;
+      if (!doWait) {
+        if (statusNode) statusNode.textContent = 'Package inventory refresh queued in background.';
+        return;
+      }
+      await pollJob(jobId, statusNode, 180000);
+    }
+
     async function confirmBlastRadius(agentIds, actionLabel, threshold = 5) {
       const resp = await fetch('/jobs/preflight', {
         method: 'POST',
@@ -513,21 +543,12 @@
           const prevCve = state.lastCveCheck?.cve || cve;
           setPatch({ lastCveUnionPackages: [], selectedCvePackages: new Set() });
           updateUpgradeControls();
+          await refreshHostInventoryCache(targets, upgradeStatusEl);
+          if (cveEl && prevCve) cveEl.value = prevCve;
+          if (upgradeStatusEl) upgradeStatusEl.textContent = 'Upgrade finished. Re-checking ' + prevCve + '…';
+          await applyVulnFilter();
           if (upgradeStatusEl) {
-            const rerunId = 'rerun-cve-' + jobId;
-            upgradeStatusEl.innerHTML = 'Upgrade finished. <a href="/jobs/' + encodeURIComponent(jobId) + '/logs.zip" target="_blank" rel="noopener noreferrer">Download logs.zip</a>. <button id="' + rerunId + '" class="btn btn-sm" type="button" style="margin-left:6px">Re-run CVE check</button>';
-            setTimeout(function () {
-              const btn = document.getElementById(rerunId);
-              if (!btn) return;
-              btn.onclick = async function () {
-                try {
-                  if (cveEl && prevCve) cveEl.value = prevCve;
-                  await applyVulnFilter();
-                } catch (e2) {
-                  upgradeStatusEl.textContent = 'Re-run failed: ' + (e2.message || e2);
-                }
-              };
-            }, 0);
+            upgradeStatusEl.innerHTML = 'Upgrade finished and CVE result refreshed. <a href="/jobs/' + encodeURIComponent(jobId) + '/logs.zip" target="_blank" rel="noopener noreferrer">Download logs.zip</a>.';
           }
         }
       } catch (e) {

--- a/server/tests/test_jobs_flow.py
+++ b/server/tests/test_jobs_flow.py
@@ -1,5 +1,6 @@
 import os
 import importlib
+from datetime import datetime, timezone
 from fastapi import HTTPException
 from sqlalchemy import select
 
@@ -229,6 +230,100 @@ def test_jobs_readonly_cannot_run_and_cannot_read_out_of_scope(monkeypatch):
 
         hidden_stdout = viewer_client.get(f"/jobs/{job_id}/runs/srv-dev/stdout.txt")
         assert hidden_stdout.status_code == 404, hidden_stdout.text
+
+
+def test_pkg_upgrade_success_invalidates_cve_cache_and_queues_inventory(monkeypatch):
+    monkeypatch.setenv("DATABASE_URL", "sqlite+pysqlite:///:memory:")
+    monkeypatch.setenv("BOOTSTRAP_USERNAME", "admin")
+    monkeypatch.setenv("BOOTSTRAP_PASSWORD", "admin-password-123")
+    monkeypatch.setenv("UI_COOKIE_SECURE", "false")
+    monkeypatch.setenv("ALLOW_INSECURE_NO_AGENT_TOKEN", "true")
+    monkeypatch.setenv("AGENT_SHARED_TOKEN", "")
+    monkeypatch.setenv("DB_AUTO_CREATE_TABLES", "true")
+    monkeypatch.setenv("DB_REQUIRE_MIGRATIONS_UP_TO_DATE", "false")
+    monkeypatch.setenv("MFA_REQUIRE_FOR_PRIVILEGED", "false")
+
+    app_factory = importlib.import_module("app.app_factory")
+    app = app_factory.create_app()
+
+    from app.db import SessionLocal
+    from app.models import Host, HostCVEStatus, Job, JobRun
+    from app.services.jobs import create_job_with_runs
+    from fastapi.testclient import TestClient
+
+    with TestClient(app) as client:
+        r = client.post(
+            "/agent/register",
+            json={
+                "agent_id": "srv-cve",
+                "hostname": "srv-cve",
+                "fqdn": None,
+                "os_id": "ubuntu",
+                "os_version": "24.04",
+                "kernel": "test",
+                "labels": {"env": "test"},
+            },
+        )
+        assert r.status_code == 200, r.text
+
+        with SessionLocal() as db:
+            host = db.execute(select(Host).where(Host.agent_id == "srv-cve")).scalar_one()
+            db.add(
+                HostCVEStatus(
+                    host_id=host.id,
+                    cve="CVE-2026-24061",
+                    affected=True,
+                    checked_at=datetime.now(timezone.utc),
+                    raw="stale vulnerable result",
+                )
+            )
+            created = create_job_with_runs(
+                db=db,
+                job_type="pkg-upgrade",
+                payload={"packages": ["openssl"], "packages_by_agent": {}, "dry_run": False},
+                agent_ids=["srv-cve"],
+                commit=False,
+            )
+            db.commit()
+
+        job_id = created.job_key
+
+        done = client.post(
+            "/agent/job-event",
+            json={
+                "agent_id": "srv-cve",
+                "job_id": job_id,
+                "status": "success",
+                "exit_code": 0,
+                "stdout": "upgrade completed",
+            },
+        )
+        assert done.status_code == 200, done.text
+
+        with SessionLocal() as db:
+            host = db.execute(select(Host).where(Host.agent_id == "srv-cve")).scalar_one()
+            stale = db.execute(
+                select(HostCVEStatus).where(
+                    HostCVEStatus.host_id == host.id,
+                    HostCVEStatus.cve == "CVE-2026-24061",
+                )
+            ).scalar_one_or_none()
+            assert stale is None
+
+            refresh = (
+                db.execute(
+                    select(JobRun, Job)
+                    .join(Job, Job.id == JobRun.job_id)
+                    .where(
+                        Job.job_type == "inventory-now",
+                        JobRun.agent_id == "srv-cve",
+                        JobRun.status == "queued",
+                    )
+                )
+                .first()
+            )
+            assert refresh is not None
+            assert refresh[1].payload["reason"] == "post-pkg-upgrade"
 
 
 def test_cleanup_offline_hosts_admin_only(monkeypatch):


### PR DESCRIPTION
## Summary
- invalidate stale per-host CVE status rows after successful package/install/dist-upgrade jobs
- queue package inventory refresh after successful upgrade jobs so installed package snapshots catch up
- make the vulnerability filter refresh inventory and automatically re-run CVE checks after CVE-driven upgrades
- fix pkg-upgrade dispatcher payload builder so queued in-memory jobs receive plain payload objects

## Tests
- PYTHONPATH=server .venv/bin/pytest server/tests/test_jobs_flow.py::test_pkg_upgrade_success_invalidates_cve_cache_and_queues_inventory -q
- PYTHONPATH=server .venv/bin/pytest server/tests/test_jobs_flow.py -q
- PYTHONPATH=server .venv/bin/pytest server/tests/test_cve_search_performance.py server/tests/test_cve_report_api.py -q
- npm run test:frontend -- server/tests/frontend/phase3-host-filters-behavior.test.js server/tests/frontend/phase3-host-filters-orchestrator.test.js
- python3 -m py_compile server/app/routers/agent.py server/app/routers/jobs.py
- git diff --check