### PR TITLE
Invalidate CVE cache on package inventory refresh

### DIFF
--- a/server/app/routers/agent.py
+++ b/server/app/routers/agent.py
@@ -93,6 +93,7 @@ def agent_inventory_packages(payload: PackagesInventory, request: Request, db: S
     collected_at = datetime.fromtimestamp(payload.collected_at_unix, tz=timezone.utc)
 
     db.execute(delete(HostPackage).where(HostPackage.host_id == host.id))
+    db.execute(delete(HostCVEStatus).where(HostCVEStatus.host_id == host.id))
     for p in payload.packages:
         name = p.get("name")
         ver = p.get("version")

--- a/server/tests/test_jobs_flow.py
+++ b/server/tests/test_jobs_flow.py
@@ -326,6 +326,84 @@ def test_pkg_upgrade_success_invalidates_cve_cache_and_queues_inventory(monkeypa
             assert refresh[1].payload["reason"] == "post-pkg-upgrade"
 
 
+def test_package_inventory_invalidates_host_cve_cache(monkeypatch):
+    monkeypatch.setenv("DATABASE_URL", "sqlite+pysqlite:///:memory:")
+    monkeypatch.setenv("BOOTSTRAP_USERNAME", "admin")
+    monkeypatch.setenv("BOOTSTRAP_PASSWORD", "admin-password-123")
+    monkeypatch.setenv("UI_COOKIE_SECURE", "false")
+    monkeypatch.setenv("ALLOW_INSECURE_NO_AGENT_TOKEN", "true")
+    monkeypatch.setenv("AGENT_SHARED_TOKEN", "")
+    monkeypatch.setenv("DB_AUTO_CREATE_TABLES", "true")
+    monkeypatch.setenv("DB_REQUIRE_MIGRATIONS_UP_TO_DATE", "false")
+    monkeypatch.setenv("MFA_REQUIRE_FOR_PRIVILEGED", "false")
+
+    app_factory = importlib.import_module("app.app_factory")
+    app = app_factory.create_app()
+
+    from app.db import SessionLocal
+    from app.models import Host, HostCVEStatus, HostPackage
+    from fastapi.testclient import TestClient
+
+    with TestClient(app) as client:
+        r = client.post(
+            "/agent/register",
+            json={
+                "agent_id": "srv-inventory-cve",
+                "hostname": "srv-inventory-cve",
+                "fqdn": None,
+                "os_id": "ubuntu",
+                "os_version": "24.04",
+                "kernel": "test",
+                "labels": {"env": "test"},
+            },
+        )
+        assert r.status_code == 200, r.text
+
+        with SessionLocal() as db:
+            host = db.execute(select(Host).where(Host.agent_id == "srv-inventory-cve")).scalar_one()
+            db.add(
+                HostCVEStatus(
+                    host_id=host.id,
+                    cve="CVE-2025-32462",
+                    affected=True,
+                    checked_at=datetime.now(timezone.utc),
+                    raw="stale vulnerable result",
+                )
+            )
+            db.commit()
+
+        inv = client.post(
+            "/agent/inventory/packages",
+            json={
+                "agent_id": "srv-inventory-cve",
+                "collected_at_unix": 1_700_000_000,
+                "packages": [
+                    {"name": "libpam-modules", "version": "1.5.3-5ubuntu5.4", "arch": "amd64"},
+                ],
+            },
+        )
+        assert inv.status_code == 200, inv.text
+
+        with SessionLocal() as db:
+            host = db.execute(select(Host).where(Host.agent_id == "srv-inventory-cve")).scalar_one()
+            stale = db.execute(
+                select(HostCVEStatus).where(
+                    HostCVEStatus.host_id == host.id,
+                    HostCVEStatus.cve == "CVE-2025-32462",
+                )
+            ).scalar_one_or_none()
+            assert stale is None
+
+            package = db.execute(
+                select(HostPackage).where(
+                    HostPackage.host_id == host.id,
+                    HostPackage.name == "libpam-modules",
+                )
+            ).scalar_one_or_none()
+            assert package is not None
+            assert package.version == "1.5.3-5ubuntu5.4"
+
+
 def test_cleanup_offline_hosts_admin_only(monkeypatch):
     monkeypatch.setenv("DATABASE_URL", "sqlite+pysqlite:///:memory:")
     monkeypatch.setenv("BOOTSTRAP_USERNAME", "admin")


### PR DESCRIPTION
After package upgrades, agents refresh package inventory. CVE status rows are derived from that package state, so fresh inventory must clear cached CVE results for the host. Otherwise stale affected rows can remain visible after an upgrade/refresh cycle.\n\nChanges:\n- Clear host_cve_status for a host whenever /agent/inventory/packages replaces that host's package inventory.\n- Add a regression test for package inventory invalidating stale CVE cache rows.\n\nChecks run:\n- PYTHONPATH=server .venv/bin/pytest server/tests/test_jobs_flow.py::test_package_inventory_invalidates_host_cve_cache server/tests/test_jobs_flow.py::test_pkg_upgrade_success_invalidates_cve_cache_and_queues_inventory -q\n- PYTHONPATH=server .venv/bin/pytest server/tests/test_jobs_flow.py server/tests/test_cve_search_performance.py server/tests/test_cve_report_api.py -q\n- npm run test:frontend -- server/tests/frontend/phase3-host-filters-behavior.test.js server/tests/frontend/phase3-host-filters-orchestrator.test.js\n- python3 -m py_compile server/app/routers/agent.py\n- git diff --check