### PR TITLE
Hide hosts when CVE filter finds none

### DIFF
--- a/server/app/templates/fleet-phase3-host-filters-vuln.js
+++ b/server/app/templates/fleet-phase3-host-filters-vuln.js
@@ -188,15 +188,16 @@
           });
 
           const unionPkgs = Array.from(union).sort();
-          syncSelectionState('vulnFilteredAgentIds', affectedIds.length ? new Set(affectedIds) : null);
+          const affectedSet = new Set(affectedIds);
+          syncSelectionState('vulnFilteredAgentIds', affectedSet);
           setPatch({
-            vulnFilteredAgentIds: affectedIds.length ? new Set(affectedIds) : null,
+            vulnFilteredAgentIds: affectedSet,
             lastCveCheck: { cve: cve, resultsByAgentId: resultsByAgentId },
             lastCveAffectedAgentIds: affectedIds,
             lastCveUnionPackages: unionPkgs,
             selectedCvePackages: new Set(unionPkgs),
           });
-          if (statusEl) statusEl.textContent = 'CVE ' + cve + ': ' + affectedIds.length + '/' + targets.length + ' host(s) affected (online). Affected packages: ' + unionPkgs.length + '. ' + (affectedIds.length ? ('Showing ' + affectedIds.length + ' affected host(s) in the list.') : 'Showing all hosts (none affected).');
+          if (statusEl) statusEl.textContent = 'CVE ' + cve + ': ' + affectedIds.length + '/' + targets.length + ' host(s) affected (online). Affected packages: ' + unionPkgs.length + '. ' + (affectedIds.length ? ('Showing ' + affectedIds.length + ' affected host(s) in the list.') : 'Showing no hosts (none affected).');
         } else {
           const params = new URLSearchParams({ name: name });
           if (version) params.set('version', version);

--- a/server/tests/frontend/phase3-host-filters-behavior.test.js
+++ b/server/tests/frontend/phase3-host-filters-behavior.test.js
@@ -96,6 +96,53 @@ describe('phase3 host-filter behavior flows', () => {
     expect(doc.getElementById('upgrade-status').textContent).toContain('CVE: CVE-2025-1234');
   });
 
+  it('keeps CVE filter empty when no hosts are affected', async () => {
+    const doc = createDocument([
+      'vuln-cve', 'vuln-package', 'vuln-version', 'vuln-apply', 'vuln-clear', 'vuln-status',
+      'select-visible-hosts', 'upgrade-selected', 'upgrade-status', 'cve-packages-panel', 'cve-packages-list', 'cve-plan-summary',
+    ]);
+    const win = {
+      window: null,
+      document: doc,
+      console,
+      fetch: async () => ({ ok: true, json: async () => ({ job_id: 'job-cve-empty' }) }),
+    };
+    win.window = win;
+    run(vulnPath, win);
+
+    const state = {
+      allHosts: [{ agent_id: 'a1' }, { agent_id: 'a2' }, { agent_id: 'a3' }],
+      selectedAgentIds: new Set(['a1']),
+      lastRenderedAgentIds: ['a1', 'a2', 'a3'],
+    };
+    let applyCount = 0;
+    const api = win.phase3HostFiltersVuln.initHostFiltersVuln({
+      getState: () => state,
+      setState: (patch) => Object.assign(state, patch),
+      syncSelectionState: (key, value) => {
+        state[key] = value;
+        return value;
+      },
+      applyHostFilters: () => { applyCount += 1; },
+      pollJob: async () => ({
+        runs: [
+          { agent_id: 'a1', status: 'success', stdout: '{"cve":"CVE-2026-3888","affected":false,"packages":[]}' },
+          { agent_id: 'a2', status: 'success', stdout: '{"cve":"CVE-2026-3888","affected":false,"packages":[]}' },
+          { agent_id: 'a3', status: 'success', stdout: '{"cve":"CVE-2026-3888","affected":false,"packages":[]}' },
+        ],
+      }),
+    });
+
+    doc.getElementById('vuln-cve').value = 'CVE-2026-3888';
+    await api.applyVulnFilter();
+
+    expect(state.vulnFilteredAgentIds.size).toBe(0);
+    expect(state.selectedAgentIds.size).toBe(0);
+    expect(doc.getElementById('vuln-status').textContent).toContain('0/3 host(s) affected');
+    expect(doc.getElementById('vuln-status').textContent).toContain('Showing no hosts');
+    expect(applyCount).toBe(1);
+  });
+
   it('select all visible hosts propagates selection + refresh callbacks', () => {
     const doc = createDocument([
       'host-search', 'label-env', 'label-role', 'labels-clear', 'labels-filter-section', 'labels-filter-toggle', 'labels-toggle-btn',


### PR DESCRIPTION
When a CVE check returns zero affected hosts, the vulnerability filter currently clears the filter by setting vulnFilteredAgentIds to null. That makes the host table show all hosts and leaves them selectable for upgrade even though the status says none are affected.\n\nChanges:\n- Keep an empty Set for zero-affected CVE results so the host list shows no hosts.\n- Update the status text to say 'Showing no hosts (none affected)'.\n- Add a frontend regression for zero-affected CVE results.\n\nChecks run:\n- npm run test:frontend -- server/tests/frontend/phase3-host-filters-behavior.test.js server/tests/frontend/phase3-host-filters-orchestrator.test.js\n- git diff --check