### PR TITLE
Refresh hosts after metadata owner save

### DIFF
--- a/server/app/templates/index.html
+++ b/server/app/templates/index.html
@@ -4475,6 +4475,10 @@
 
             rebuildLabelFilterOptions(allHosts);
             applyHostFilters();
+            void Promise.allSettled([
+              loadHostsTable(),
+              loadHosts(),
+            ]);
           }
         });
       }

--- a/server/tests/frontend/phase3-host-actions-metadata.test.js
+++ b/server/tests/frontend/phase3-host-actions-metadata.test.js
@@ -63,4 +63,11 @@ describe('phase3 host metadata payload normalization', () => {
     expect(html).toContain('id="host-meta-owner"');
     expect(html).toContain('Owner username (blank to clear)');
   });
+
+  it('refreshes dashboard host data after metadata save', () => {
+    const html = fs.readFileSync(indexPath, 'utf8');
+    expect(html).toContain('onMetadataSaved: (updatedHost) => {');
+    expect(html).toContain('loadHostsTable()');
+    expect(html).toContain('loadHosts()');
+  });
 });


### PR DESCRIPTION
Saving Owner username through the dashboard host metadata editor updated the backend, but the dashboard table/sidebar data was not refreshed afterward. That made the Owner column and owner filter continue showing the old value or blank state.\n\nChanges:\n- After successful metadata save, reload the dashboard hosts table and host list.\n- Add a frontend regression to keep this refresh wired.\n\nChecks run:\n- npm run test:frontend -- server/tests/frontend/phase3-host-actions-metadata.test.js server/tests/frontend/hosts-sort-owner.test.js server/tests/frontend/hosts-filter-owner.test.js\n- git diff --check