### PR TITLE
Align security and login styling

### DIFF
--- a/server/app/templates/fleet-ui-v2.css
+++ b/server/app/templates/fleet-ui-v2.css
@@ -18,9 +18,6 @@
   --chart-point: #0f766e;
   --disk-usage-track: rgba(148, 163, 184, 0.24);
   --sudo-mode-label-text: var(--text);
-  --sudo-mode-select-bg: color-mix(in srgb, var(--panel) 98%, #ffffff);
-  --sudo-mode-select-border: #d9e3ef;
-  --sudo-mode-select-text: var(--text);
   --nav-indicator-error: #dc2626;
   --nav-indicator-warn: #d97706;
   --report-th-bg: color-mix(in srgb, var(--panel-2) 92%, #ffffff);
@@ -46,10 +43,7 @@
   --chart-line: #667eea;
   --chart-point: #667eea;
   --disk-usage-track: rgba(148, 163, 184, 0.25);
-  --sudo-mode-label-text: #e6f0ff;
-  --sudo-mode-select-bg: #0b1422;
-  --sudo-mode-select-border: #2d4f73;
-  --sudo-mode-select-text: #e6f0ff;
+  --sudo-mode-label-text: var(--text);
   --nav-indicator-error: #ef4444;
   --nav-indicator-warn: #f59e0b;
   --report-th-bg: #111827;
@@ -330,23 +324,31 @@ body {
   font-size: 12px;
 }
 
+.sudo-mode-label {
+  gap: 0.45rem;
+  font-size: 0.875rem;
+  font-weight: 400;
+  color: var(--muted);
+  padding: 0;
+}
+
 #sshkey-sudo-mode {
-  color: var(--sudo-mode-select-text) !important;
-  background: var(--sudo-mode-select-bg) !important;
-  border-color: var(--sudo-mode-select-border) !important;
+  color: var(--text) !important;
+  background: var(--panel) !important;
+  border-color: var(--border) !important;
   opacity: 1 !important;
-  height: 36px !important;
+  min-height: 2rem !important;
+  height: 2rem !important;
   line-height: 1.25 !important;
-  padding-top: 0 !important;
-  padding-bottom: 0 !important;
-  padding-left: .65rem !important;
-  padding-right: 1.8rem !important;
-  font-size: 15px !important;
+  padding: 0.375rem 1.8rem 0.375rem 0.5rem !important;
+  border-radius: 3px !important;
+  font-size: 0.875rem !important;
+  font-weight: 400 !important;
 }
 
 #sshkey-sudo-mode option {
-  color: var(--sudo-mode-select-text);
-  background: var(--sudo-mode-select-bg);
+  color: var(--text);
+  background: var(--panel);
   line-height: 1.25;
 }
 

--- a/server/app/templates/index.html
+++ b/server/app/templates/index.html
@@ -888,7 +888,7 @@
               <button class="btn" id="sshkey-hosts-open" type="button">Choose hosts…</button>
               <label class="sudo-mode-label">
                 <span>Sudo access:</span>
-                <select id="sshkey-sudo-mode" class="host-search" style="min-width:260px;font-weight:600;color:var(--text);">
+                <select id="sshkey-sudo-mode" class="host-search" style="min-width:260px;">
                   <option value="restricted" selected>Restricted sudo</option>
                   <option value="full">Full sudo (admin-like)</option>
                   <option value="none">No sudo</option>

--- a/server/app/templates/login.html
+++ b/server/app/templates/login.html
@@ -6,45 +6,51 @@
   <script src="/assets/fleet-theme-bootstrap.js?v=__ASSET_VERSION__"></script>
   <style>
     :root {
-      --bg: #f8fafc;
+      --bg: #f4f7fb;
       --panel: #ffffff;
-      --border: #e2e8f0;
+      --panel-2: #f8fafc;
+      --border: #d9e3f0;
       --text: #0f172a;
       --muted: #475569;
       --primary: #2563eb;
-      --shadow: rgba(2, 6, 23, 0.08);
+      --primary-2: #1e40af;
+      --focus-ring: rgba(37, 99, 235, 0.25);
       --oidc-bg: #0f766e;
     }
     :root[data-theme="dark"] {
-      --bg: #0b1220;
+      --bg: #050a13;
       --panel: #0f172a;
-      --border: #1f2937;
-      --text: #e2e8f0;
-      --muted: #94a3b8;
+      --panel-2: #111827;
+      --border: #173044;
+      --text: #e5e7eb;
+      --muted: #a3a3a3;
       --primary: #2563eb;
-      --shadow: rgba(0,0,0,0.45);
+      --primary-2: #1e3a8a;
+      --focus-ring: rgba(59, 130, 246, 0.25);
       --oidc-bg: #0f766e;
     }
     /* Prevent 100% width inputs from overflowing due to padding/borders */
     *, *::before, *::after { box-sizing: border-box; }
 
-    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; background:var(--bg); margin:0; min-height:100vh; display:flex; align-items:center; justify-content:center; color:var(--text); }
-    .card { background:var(--panel); border:1px solid var(--border); border-radius:12px; padding:1.5rem; width:380px; max-width:92vw; box-shadow:0 10px 30px var(--shadow); }
+    body { font-family:"Inter", "IBM Plex Sans", "Noto Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif; background:var(--bg); margin:0; min-height:100vh; display:flex; align-items:center; justify-content:center; color:var(--text); }
+    .card { background:var(--panel); border:1px solid var(--border); border-radius:3px; padding:1.25rem; width:380px; max-width:92vw; box-shadow:none; }
     .card-head { display:flex; align-items:center; justify-content:space-between; gap:0.75rem; }
-    .theme-btn { border:1px solid var(--border); background:transparent; color:var(--muted); border-radius:10px; padding:0.4rem 0.6rem; cursor:pointer; font-weight:600; }
-    h1 { font-size:1.25rem; margin:0 0 1rem 0; }
-    label { display:block; font-size:0.85rem; color:var(--muted); margin-top:0.75rem; }
-    input { width:100%; padding:0.65rem 0.75rem; border:1px solid var(--border); border-radius:10px; font-size:0.95rem; outline:none; background: #fff; }
-    :root[data-theme="dark"] input { background: rgba(255,255,255,0.04); color: var(--text); }
-    input:focus { border-color:#1d4ed8; box-shadow:0 0 0 3px rgba(29,78,216,0.15); }
-    button { margin-top:1rem; width:100%; padding:0.7rem 0.75rem; border:none; border-radius:10px; background:#1d4ed8; color:white; font-weight:700; cursor:pointer; }
+    .theme-btn { width:auto; min-height:2rem; margin-top:0; border:1px solid var(--border); background:var(--panel); color:var(--text); border-radius:3px; padding:0.375rem 0.75rem; cursor:pointer; font-weight:400; }
+    h1 { font-size:1.25rem; line-height:1.2; margin:0 0 1rem 0; font-weight:600; }
+    label { display:block; font-size:0.875rem; color:var(--muted); margin-top:0.75rem; }
+    input { width:100%; min-height:2rem; padding:0.375rem 0.5rem; border:1px solid var(--border); border-radius:3px; font-size:0.875rem; outline:none; background:var(--panel); color:var(--text); }
+    input:focus { outline:2px solid var(--focus-ring); outline-offset:1px; box-shadow:none; }
+    button { margin-top:1rem; width:100%; min-height:2rem; padding:0.375rem 0.75rem; border:1px solid var(--primary); border-radius:3px; background:var(--primary); color:white; font-size:0.875rem; font-weight:400; cursor:pointer; }
+    button:hover { background:var(--primary-2); border-color:var(--primary-2); }
     .btn-oidc { background: var(--oidc-bg); }
+    .btn-oidc:hover { background:color-mix(in srgb, var(--oidc-bg) 82%, #000); border-color:color-mix(in srgb, var(--oidc-bg) 82%, #000); }
+    .theme-btn:hover { border-color:color-mix(in srgb, var(--border) 50%, var(--text)); background:var(--panel-2); }
     button:disabled { opacity:0.6; cursor:not-allowed; }
     .err { display:none; }
     .hint { margin-top:0.75rem; color:var(--muted); font-size:0.8rem; }
     .caps-hint { margin-top:0.5rem; color:#b45309; font-size:0.8rem; display:none; }
     .toast-container { position:fixed; right:1.5rem; bottom:1.5rem; display:flex; flex-direction:column; gap:0.75rem; z-index:2000; pointer-events:none; }
-    .toast { background:var(--panel); color:var(--text); border:1px solid var(--border); padding:0.7rem 0.95rem; border-radius:10px; min-width:200px; max-width:320px; box-shadow:0 12px 30px var(--shadow); opacity:0; transform:translateY(8px); transition:opacity 0.2s ease, transform 0.2s ease; }
+    .toast { background:var(--panel); color:var(--text); border:1px solid var(--border); padding:0.7rem 0.95rem; border-radius:3px; min-width:200px; max-width:320px; box-shadow:none; opacity:0; transform:translateY(8px); transition:opacity 0.2s ease, transform 0.2s ease; }
     .toast.show { opacity:1; transform:translateY(0); }
     .toast-success { border-color: rgba(16, 185, 129, 0.5); }
     .toast-error { border-color: rgba(239, 68, 68, 0.6); }


### PR DESCRIPTION
## Summary
- normalize the Security menu Sudo access label/dropdown to the updated compact control styling
- remove stale inline styling from the sudo select
- refresh the login page controls/card/toasts to match the newer Cockpit-like UI

## Tests
- npm run test:frontend -- server/tests/frontend/service-management-navigation.test.js
- python3 scripts/theme-audit.py server/app/templates/fleet-ui-v2.css
- git diff --check