### PR TITLE
Allow regular users to save personal views

### DIFF
--- a/server/app/templates/fleet-phase3-host-filters-ui.js
+++ b/server/app/templates/fleet-phase3-host-filters-ui.js
@@ -6,6 +6,7 @@
     const syncSelectionState = typeof api.syncSelectionState === 'function' ? api.syncSelectionState : function (_, v) { return v; };
     const applyHostFilters = typeof api.applyHostFilters === 'function' ? api.applyHostFilters : function () { };
     const updateUpgradeControls = typeof api.updateUpgradeControls === 'function' ? api.updateUpgradeControls : function () { };
+    const getCurrentPermissions = typeof api.getCurrentPermissions === 'function' ? api.getCurrentPermissions : function () { return {}; };
 
     const searchEl = document.getElementById('host-search');
     const envSel = document.getElementById('label-env');
@@ -63,6 +64,31 @@
       savedViewStatusEl.textContent = msg || '';
       savedViewStatusEl.style.color = (kind === 'error') ? 'var(--danger)' : (kind === 'success' ? 'var(--success)' : 'var(--muted-2)');
     }
+
+    function canShareSavedViews() {
+      const perms = getCurrentPermissions() || {};
+      return String(perms.role || '').toLowerCase() === 'admin' || !!perms.can_manage_users;
+    }
+
+    function canEditSelectedView(view) {
+      return !view || !!view.can_edit;
+    }
+
+    function syncSavedViewPermissionControls(view) {
+      const mayEdit = canEditSelectedView(view);
+      const mayShare = canShareSavedViews();
+      if (savedViewSharedEl) {
+        savedViewSharedEl.disabled = !mayEdit || !mayShare;
+        savedViewSharedEl.checked = !!(view && view.is_shared);
+      }
+      if (savedViewDefaultEl) {
+        savedViewDefaultEl.disabled = !mayEdit;
+        savedViewDefaultEl.checked = !!(view && view.is_default_startup);
+      }
+      if (savedViewDeleteBtn) savedViewDeleteBtn.disabled = !mayEdit;
+    }
+
+    syncSavedViewPermissionControls(null);
 
     async function fetchSavedViews() {
       const r = await fetch('/auth/views?scope=hosts', { credentials: 'include', cache: 'no-store' });
@@ -210,8 +236,8 @@
             scope: 'hosts',
             name,
             payload: current,
-            is_shared: !!savedViewSharedEl?.checked,
-            is_default_startup: !!savedViewDefaultEl?.checked,
+            is_shared: !!(savedViewSharedEl && !savedViewSharedEl.disabled && savedViewSharedEl.checked),
+            is_default_startup: !!(savedViewDefaultEl && !savedViewDefaultEl.disabled && savedViewDefaultEl.checked),
           }),
         });
         if (!r.ok) throw new Error(`save failed (${r.status})`);
@@ -240,8 +266,7 @@
       }
       applySavedView(view.payload || {}, { viewName: String(view.name || '') });
       if (savedViewNameEl) savedViewNameEl.value = String(view.name || '');
-      if (savedViewSharedEl) savedViewSharedEl.checked = !!view.is_shared;
-      if (savedViewDefaultEl) savedViewDefaultEl.checked = !!view.is_default_startup;
+      syncSavedViewPermissionControls(view);
       setSavedViewStatus(`Applied view "${String(view.name || '')}".`, 'success');
     });
 
@@ -278,15 +303,7 @@
       const view = (savedViewsCache || []).find((it) => viewKey(it) === key);
       if (!view) return;
       if (savedViewNameEl) savedViewNameEl.value = String(view.name || '');
-      if (savedViewSharedEl) {
-        savedViewSharedEl.checked = !!view.is_shared;
-        savedViewSharedEl.disabled = !view.can_edit;
-      }
-      if (savedViewDefaultEl) {
-        savedViewDefaultEl.checked = !!view.is_default_startup;
-        savedViewDefaultEl.disabled = !view.can_edit;
-      }
-      if (savedViewDeleteBtn) savedViewDeleteBtn.disabled = !view.can_edit;
+      syncSavedViewPermissionControls(view);
       setSavedViewStatus('Click Apply to use selected view.', null);
     });
 
@@ -312,9 +329,7 @@
           applySavedView(target.payload || {}, { viewName: String(target.name || '') });
           if (savedViewSelectEl) savedViewSelectEl.value = viewKey(target);
           if (savedViewNameEl) savedViewNameEl.value = String(target.name || '');
-          if (savedViewSharedEl) savedViewSharedEl.checked = !!target.is_shared;
-          if (savedViewDefaultEl) savedViewDefaultEl.checked = !!target.is_default_startup;
-          if (savedViewDeleteBtn) savedViewDeleteBtn.disabled = !target.can_edit;
+          syncSavedViewPermissionControls(target);
           setSavedViewStatus(`Applied view "${String(target.name || '')}".`, 'success');
         }
       } catch (_) {

--- a/server/app/templates/fleet-phase3-host-filters.js
+++ b/server/app/templates/fleet-phase3-host-filters.js
@@ -20,6 +20,7 @@
       syncSelectionState: api.syncSelectionState,
       applyHostFilters: api.applyHostFilters,
       updateUpgradeControls: function () { updateUpgradeControls(); },
+      getCurrentPermissions: api.getCurrentPermissions,
     }) || {};
 
     const vulnOut = vulnModule.initHostFiltersVuln({

--- a/server/app/templates/index.html
+++ b/server/app/templates/index.html
@@ -3062,6 +3062,7 @@
         pollJob: window.pollJob,
         escapeHtml,
         matchesGlob,
+        getCurrentPermissions: () => currentPermissions,
       });
 
       updateUpgradeControlsFn = (out && typeof out.updateUpgradeControls === 'function')

--- a/server/tests/frontend/phase3-host-filters-behavior.test.js
+++ b/server/tests/frontend/phase3-host-filters-behavior.test.js
@@ -245,4 +245,65 @@ describe('phase3 host-filter behavior flows', () => {
 
     expect(doc.getElementById('saved-view-select').innerHTML).toContain('Prod DBs (shared by admin)');
   });
+
+  it('saves a regular user personal view without carrying disabled shared state', async () => {
+    const doc = createDocument([
+      'host-search', 'label-env', 'label-role', 'label-owner',
+      'labels-clear', 'labels-filter-section', 'labels-filter-toggle', 'labels-toggle-btn',
+      'select-visible-hosts', 'vuln-filter-section', 'vuln-filter-toggle', 'vuln-toggle-btn',
+      'ansible-filter-section', 'ansible-filter-toggle', 'ansible-toggle-btn',
+      'saved-view-name', 'saved-view-select', 'saved-view-save', 'saved-view-apply',
+      'saved-view-delete', 'saved-view-shared', 'saved-view-default', 'saved-view-status',
+    ]);
+    let posted = null;
+    const sharedItem = {
+      name: 'Prod DBs',
+      owner_username: 'admin',
+      is_shared: true,
+      is_default_startup: false,
+      can_edit: false,
+      payload: { labelEnvFilter: 'prod', labelRoleFilter: 'db' },
+    };
+    const win = {
+      window: null,
+      document: doc,
+      console,
+      escapeHtml: (s) => String(s).replaceAll('&', '&amp;').replaceAll('<', '&lt;').replaceAll('>', '&gt;').replaceAll('"', '&quot;'),
+      fetch: async (url, opts = {}) => {
+        if (String(url) === '/auth/views' && opts.method === 'POST') {
+          posted = JSON.parse(String(opts.body || '{}'));
+          return { ok: true, json: async () => ({ ok: true }) };
+        }
+        return {
+          ok: true,
+          json: async () => ({ items: [sharedItem] }),
+        };
+      },
+    };
+    win.window = win;
+    run(uiPath, win);
+
+    win.phase3HostFiltersUi.initHostFiltersUi({
+      getState: () => ({}),
+      setState: () => {},
+      syncSelectionState: (_, value) => value,
+      applyHostFilters: () => {},
+      getCurrentPermissions: () => ({ role: 'readonly' }),
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    const shared = doc.getElementById('saved-view-shared');
+    doc.getElementById('saved-view-select').value = 'Prod DBs@@admin@@1';
+    doc.getElementById('saved-view-select').dispatch('change');
+    expect(shared.checked).toBe(true);
+    expect(shared.disabled).toBe(true);
+
+    doc.getElementById('saved-view-name').value = 'My view';
+    doc.getElementById('saved-view-save').dispatch('click');
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(posted.name).toBe('My view');
+    expect(posted.is_shared).toBe(false);
+  });
 });


### PR DESCRIPTION
## Summary
- pass current permissions into the host saved-view UI
- disable team sharing for non-admin users while still allowing personal saved views
- prevent disabled Shared/Default checkboxes from being sent in save payloads
- add regression coverage for saving a personal view after selecting a shared team view

## Tests
- npm run test:frontend -- server/tests/frontend/phase3-host-filters-behavior.test.js server/tests/frontend/phase3-host-filters-orchestrator.test.js server/tests/frontend/hosts-filter-owner.test.js
- git diff --check