### PR TITLE
Maximize embedded console height

### DIFF
--- a/server/app/templates/fleet-ui-v2.css
+++ b/server/app/templates/fleet-ui-v2.css
@@ -625,6 +625,23 @@ body {
   overflow: visible;
 }
 
+.fleet-main-shell:has(#terminal-tab.active) {
+  display: flex;
+  flex-direction: column;
+  height: calc(100vh - 52px);
+  min-height: calc(100vh - 52px);
+  overflow: hidden;
+}
+
+.fleet-main-shell:has(#terminal-tab.active) #terminal-tab.active {
+  flex: 1 1 auto;
+  min-height: 0;
+}
+
+.fleet-main-shell:has(#terminal-tab.active) #terminal {
+  min-height: 0;
+}
+
 #host-actions {
   padding: 0.75rem 1rem !important;
   border-bottom: 1px solid var(--border);
@@ -1016,5 +1033,10 @@ a,
 
   .fleet-main-shell {
     min-height: auto;
+  }
+
+  .fleet-main-shell:has(#terminal-tab.active) {
+    height: auto;
+    min-height: calc(100vh - 52px);
   }
 }


### PR DESCRIPTION
## Summary
- let the host console shell use the full viewport height under the existing top and left menus
- make the embedded terminal fill the remaining console tab area instead of stopping around half screen

## Tests
- python3 scripts/theme-audit.py server/app/templates/fleet-ui-v2.css
- npm run test:frontend -- server/tests/frontend/phase3-host-actions-metadata.test.js server/tests/frontend/phase3-core-state.test.js
- git diff --check