### PR TITLE
Add RPM and RHEL support

### DIFF
--- a/agent/cmd/fleet-agent/main.go
+++ b/agent/cmd/fleet-agent/main.go
@@ -8,9 +8,11 @@ import (
 	"github.com/yourorg/fleet-agent/internal"
 	"io"
 	"log"
+	"net"
 	"net/http"
 	"os"
 	"os/exec"
+	"runtime"
 	"strconv"
 	"strings"
 	"sync"
@@ -163,15 +165,17 @@ func main() {
 				}
 				mustPostJSON(client, cfg.ServerURL+"/agent/inventory/packages", inv, cfg.AgentToken)
 				// Also send upgradable package snapshot (no apt-get update here; uses local apt cache)
-				if updates, uerr := collectUpgradablePackages(ctx); uerr == nil {
-					upInv := UpdatesInventoryPayload{
-						AgentID:       cfg.AgentID,
-						CheckedAtUnix: time.Now().Unix(),
-						Updates:       updates,
-					}
-					mustPostJSON(client, cfg.ServerURL+"/agent/inventory/package-updates", upInv, cfg.AgentToken)
-				}
 				lastInv = now
+				go func() {
+					if updates, uerr := collectUpgradablePackages(context.Background()); uerr == nil {
+						upInv := UpdatesInventoryPayload{
+							AgentID:       cfg.AgentID,
+							CheckedAtUnix: time.Now().Unix(),
+							Updates:       updates,
+						}
+						mustPostJSON(client, cfg.ServerURL+"/agent/inventory/package-updates", upInv, cfg.AgentToken)
+					}
+				}()
 			} else {
 				fmt.Fprintf(os.Stderr, "inventory error: %v\n", err)
 			}
@@ -2294,14 +2298,7 @@ func querySystemMetrics(ctx context.Context) (string, string, int, string) {
 	}
 
 	// Get CPU info (vCPUs and load)
-	// Get vCPU count from /proc/cpuinfo
-	cpuInfoCmd := exec.CommandContext(queryCtx, "grep", "-c", "^processor", "/proc/cpuinfo")
-	cpuInfoOut, err := cpuInfoCmd.Output()
-	if err == nil {
-		var vcpus int
-		fmt.Sscanf(strings.TrimSpace(string(cpuInfoOut)), "%d", &vcpus)
-		metrics.CPU.VCPUs = vcpus
-	}
+	metrics.CPU.VCPUs = runtime.NumCPU()
 
 	// Get load average from /proc/loadavg
 	loadCmd := exec.CommandContext(queryCtx, "cat", "/proc/loadavg")
@@ -2314,23 +2311,10 @@ func querySystemMetrics(ctx context.Context) (string, string, int, string) {
 		metrics.CPU.Load15Min = load15
 	}
 
-	// Get IP addresses using ip or ifconfig
-	ipCmd := exec.CommandContext(queryCtx, "ip", "-4", "addr", "show")
-	ipOut, err := ipCmd.Output()
-	if err == nil {
-		lines := strings.Split(string(ipOut), "\n")
-		for _, line := range lines {
-			line = strings.TrimSpace(line)
-			if strings.HasPrefix(line, "inet ") {
-				parts := strings.Fields(line)
-				if len(parts) >= 2 {
-					ip := strings.Split(parts[1], "/")[0]
-					if ip != "127.0.0.1" {
-						metrics.IPAddresses = append(metrics.IPAddresses, ip)
-					}
-				}
-			}
-		}
+	// Get IP addresses using Go's network interfaces first; shell tools can be
+	// absent on minimal RHEL installs.
+	if ips := localIPv4Addresses(); len(ips) > 0 {
+		metrics.IPAddresses = ips
 	} else {
 		// Fallback to ifconfig
 		ifconfigCmd := exec.CommandContext(queryCtx, "ifconfig")
@@ -2363,6 +2347,46 @@ func querySystemMetrics(ctx context.Context) (string, string, int, string) {
 	}
 
 	return string(jsonOut), "", 0, ""
+}
+
+func localIPv4Addresses() []string {
+	var out []string
+	ifaces, err := net.Interfaces()
+	if err != nil {
+		return out
+	}
+	seen := map[string]bool{}
+	for _, iface := range ifaces {
+		if iface.Flags&net.FlagUp == 0 || iface.Flags&net.FlagLoopback != 0 {
+			continue
+		}
+		addrs, err := iface.Addrs()
+		if err != nil {
+			continue
+		}
+		for _, addr := range addrs {
+			var ip net.IP
+			switch v := addr.(type) {
+			case *net.IPNet:
+				ip = v.IP
+			case *net.IPAddr:
+				ip = v.IP
+			}
+			if ip == nil {
+				continue
+			}
+			ip4 := ip.To4()
+			if ip4 == nil || ip4.IsLoopback() {
+				continue
+			}
+			s := ip4.String()
+			if !seen[s] {
+				seen[s] = true
+				out = append(out, s)
+			}
+		}
+	}
+	return out
 }
 
 func queryTopProcesses(ctx context.Context) (string, string, int, string) {

--- a/agent/cmd/fleet-agent/main.go
+++ b/agent/cmd/fleet-agent/main.go
@@ -40,6 +40,7 @@ type RegisterPayload struct {
 type InventoryPayload struct {
 	AgentID         string        `json:"agent_id"`
 	CollectedAtUnix int64         `json:"collected_at_unix"`
+	Manager         string        `json:"manager,omitempty"`
 	Packages        []PackageItem `json:"packages"`
 }
 
@@ -152,11 +153,12 @@ func main() {
 		now := time.Now()
 
 		if lastInv.IsZero() || now.Sub(lastInv) >= cfg.InvEvery {
-			pkgs, err := collectDpkgPackages(ctx)
+			pkgs, manager, err := collectPackages(ctx)
 			if err == nil {
 				inv := InventoryPayload{
 					AgentID:         cfg.AgentID,
 					CollectedAtUnix: time.Now().Unix(),
+					Manager:         manager,
 					Packages:        pkgs,
 				}
 				mustPostJSON(client, cfg.ServerURL+"/agent/inventory/packages", inv, cfg.AgentToken)
@@ -242,8 +244,63 @@ func mustPostJSON(client *http.Client, url string, payload any, token string) {
 	}
 }
 
+func detectPackageManager() string {
+	if _, err := exec.LookPath("dpkg-query"); err == nil {
+		return "dpkg"
+	}
+	if _, err := exec.LookPath("rpm"); err == nil {
+		return "rpm"
+	}
+	return ""
+}
+
+func rpmFrontend() string {
+	if _, err := exec.LookPath("dnf"); err == nil {
+		return "dnf"
+	}
+	if _, err := exec.LookPath("yum"); err == nil {
+		return "yum"
+	}
+	return ""
+}
+
+func collectPackages(ctx context.Context) ([]PackageItem, string, error) {
+	switch detectPackageManager() {
+	case "dpkg":
+		pkgs, err := collectDpkgPackages(ctx)
+		return pkgs, "dpkg", err
+	case "rpm":
+		pkgs, err := collectRpmPackages(ctx)
+		return pkgs, "rpm", err
+	default:
+		return nil, "", fmt.Errorf("no supported package manager found")
+	}
+}
+
 func collectDpkgPackages(ctx context.Context) ([]PackageItem, error) {
 	cmd := exec.CommandContext(ctx, "dpkg-query", "-W", "-f", "${Package}|${Version}|${Architecture}\n")
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, err
+	}
+	lines := strings.Split(strings.ReplaceAll(string(out), "\r\n", "\n"), "\n")
+	pkgs := make([]PackageItem, 0, len(lines))
+	for _, l := range lines {
+		l = strings.TrimSpace(l)
+		if l == "" {
+			continue
+		}
+		parts := strings.Split(l, "|")
+		if len(parts) != 3 {
+			continue
+		}
+		pkgs = append(pkgs, PackageItem{Name: parts[0], Version: parts[1], Arch: parts[2]})
+	}
+	return pkgs, nil
+}
+
+func collectRpmPackages(ctx context.Context) ([]PackageItem, error) {
+	cmd := exec.CommandContext(ctx, "rpm", "-qa", "--qf", "%{NAME}|%{VERSION}-%{RELEASE}|%{ARCH}\n")
 	out, err := cmd.Output()
 	if err != nil {
 		return nil, err
@@ -874,12 +931,18 @@ func queryPkgVersions(ctx context.Context, packages []string) (string, string, i
 	}
 
 	out := make([]PkgVersion, 0, len(packages))
+	manager := detectPackageManager()
 	for _, name := range packages {
 		name = strings.TrimSpace(name)
 		if name == "" {
 			continue
 		}
-		cmd := exec.CommandContext(queryCtx, "dpkg-query", "-W", "-f", "${Version}", name)
+		var cmd *exec.Cmd
+		if manager == "rpm" {
+			cmd = exec.CommandContext(queryCtx, "rpm", "-q", "--qf", "%{VERSION}-%{RELEASE}", name)
+		} else {
+			cmd = exec.CommandContext(queryCtx, "dpkg-query", "-W", "-f", "${Version}", name)
+		}
 		b, err := cmd.Output()
 		if err != nil {
 			out = append(out, PkgVersion{Name: name, Found: false})
@@ -903,6 +966,9 @@ func queryPkgInfo(ctx context.Context, pkgName string) (string, string, int, str
 	pkgName = strings.TrimSpace(pkgName)
 	if pkgName == "" {
 		return "", "", 1, "package_name is required"
+	}
+	if detectPackageManager() == "rpm" {
+		return queryRpmPkgInfo(queryCtx, pkgName)
 	}
 
 	type PkgInfo struct {
@@ -1037,7 +1103,108 @@ func queryPkgInfo(ctx context.Context, pkgName string) (string, string, int, str
 	return string(j), "", 0, ""
 }
 
+func queryRpmPkgInfo(ctx context.Context, pkgName string) (string, string, int, string) {
+	type PkgInfo struct {
+		Name             string                 `json:"name"`
+		InstalledVersion string                 `json:"installed_version,omitempty"`
+		CandidateVersion string                 `json:"candidate_version,omitempty"`
+		Architecture     string                 `json:"architecture,omitempty"`
+		Section          string                 `json:"section,omitempty"`
+		Priority         string                 `json:"priority,omitempty"`
+		Maintainer       string                 `json:"maintainer,omitempty"`
+		Homepage         string                 `json:"homepage,omitempty"`
+		Summary          string                 `json:"summary,omitempty"`
+		Description      string                 `json:"description,omitempty"`
+		Raw              map[string]interface{} `json:"raw,omitempty"`
+	}
+
+	info := PkgInfo{Name: pkgName, Raw: map[string]interface{}{}}
+
+	rpmCmd := exec.CommandContext(ctx, "rpm", "-qi", pkgName)
+	rpmOut, rpmErr := rpmCmd.CombinedOutput()
+	info.Raw["rpm_info"] = string(rpmOut)
+	if rpmErr == nil {
+		for _, line := range strings.Split(string(rpmOut), "\n") {
+			if key, val, ok := strings.Cut(line, ":"); ok {
+				key = strings.TrimSpace(strings.ToLower(key))
+				val = strings.TrimSpace(val)
+				switch key {
+				case "version":
+					info.InstalledVersion = val
+				case "release":
+					if info.InstalledVersion != "" && val != "" {
+						info.InstalledVersion = info.InstalledVersion + "-" + val
+					}
+				case "architecture":
+					info.Architecture = val
+				case "group":
+					info.Section = val
+				case "vendor", "packager":
+					if info.Maintainer == "" {
+						info.Maintainer = val
+					}
+				case "url":
+					info.Homepage = val
+				case "summary":
+					info.Summary = val
+				case "description":
+					info.Description = val
+				}
+			}
+		}
+	}
+
+	if frontend := rpmFrontend(); frontend != "" {
+		dnfCmd := exec.CommandContext(ctx, frontend, "info", pkgName)
+		dnfOut, _ := dnfCmd.CombinedOutput()
+		info.Raw[frontend+"_info"] = string(dnfOut)
+		for _, line := range strings.Split(string(dnfOut), "\n") {
+			if key, val, ok := strings.Cut(line, ":"); ok {
+				key = strings.TrimSpace(strings.ToLower(key))
+				val = strings.TrimSpace(val)
+				switch key {
+				case "available packages":
+					continue
+				case "version":
+					if info.CandidateVersion == "" {
+						info.CandidateVersion = val
+					}
+				case "release":
+					if info.CandidateVersion != "" && val != "" && !strings.Contains(info.CandidateVersion, "-") {
+						info.CandidateVersion = info.CandidateVersion + "-" + val
+					}
+				case "arch":
+					if info.Architecture == "" {
+						info.Architecture = val
+					}
+				case "summary":
+					if info.Summary == "" {
+						info.Summary = val
+					}
+				case "url":
+					if info.Homepage == "" {
+						info.Homepage = val
+					}
+				}
+			}
+		}
+	}
+
+	j, err := json.Marshal(info)
+	if err != nil {
+		return "", "", 1, fmt.Sprintf("JSON marshal failed: %v", err)
+	}
+	return string(j), "", 0, ""
+}
+
 func queryPkgUpdates(ctx context.Context, refresh bool) (string, string, int, string) {
+	if detectPackageManager() == "rpm" {
+		return queryRpmPkgUpdates(ctx, refresh)
+	}
+	return queryAptPkgUpdates(ctx, refresh)
+}
+
+func queryAptPkgUpdates(ctx context.Context, refresh bool) (string, string, int, string) {
 	// Compute list of upgradable packages using apt. Optionally refresh package lists.
 	// Also tries to classify which upgrades are security updates via `pro security-status --format json`.
 	queryCtx, cancel := context.WithTimeout(ctx, 180*time.Second)
@@ -1168,6 +1335,137 @@ func queryPkgUpdates(ctx context.Context, refresh bool) (string, string, int, st
 	return string(j), "", 0, ""
 }
 
+type rpmUpdateLine struct {
+	Name             string
+	Arch             string
+	CandidateVersion string
+}
+
+func splitRpmNameArch(nameArch string) (string, string) {
+	nameArch = strings.TrimSpace(nameArch)
+	if nameArch == "" {
+		return "", ""
+	}
+	if idx := strings.LastIndex(nameArch, "."); idx > 0 && idx < len(nameArch)-1 {
+		return nameArch[:idx], nameArch[idx+1:]
+	}
+	return nameArch, ""
+}
+
+func parseRpmCheckUpdateLine(line string) (rpmUpdateLine, bool) {
+	line = strings.TrimSpace(line)
+	if line == "" || strings.HasPrefix(line, "Last metadata expiration check:") {
+		return rpmUpdateLine{}, false
+	}
+	if strings.HasPrefix(line, "Security:") || strings.HasPrefix(line, "Obsoleting Packages") {
+		return rpmUpdateLine{}, false
+	}
+	parts := strings.Fields(line)
+	if len(parts) < 2 {
+		return rpmUpdateLine{}, false
+	}
+	name, arch := splitRpmNameArch(parts[0])
+	if name == "" || strings.ContainsAny(name, " \t:") {
+		return rpmUpdateLine{}, false
+	}
+	return rpmUpdateLine{Name: name, Arch: arch, CandidateVersion: parts[1]}, true
+}
+
+func installedRpmVersion(ctx context.Context, name string) string {
+	cmd := exec.CommandContext(ctx, "rpm", "-q", "--qf", "%{VERSION}-%{RELEASE}", name)
+	b, err := cmd.Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(b))
+}
+
+func rpmSecurityUpdateNames(ctx context.Context, frontend string) map[string]bool {
+	names := map[string]bool{}
+	cmd := exec.CommandContext(ctx, frontend, "updateinfo", "list", "updates", "security")
+	b, err := cmd.CombinedOutput()
+	if err != nil && len(b) == 0 {
+		return names
+	}
+	for _, line := range strings.Split(strings.ReplaceAll(string(b), "\r\n", "\n"), "\n") {
+		parts := strings.Fields(strings.TrimSpace(line))
+		if len(parts) < 3 {
+			continue
+		}
+		name, _ := splitRpmNameArch(parts[len(parts)-1])
+		if name != "" {
+			names[name] = true
+		}
+	}
+	return names
+}
+
+func queryRpmPkgUpdates(ctx context.Context, refresh bool) (string, string, int, string) {
+	queryCtx, cancel := context.WithTimeout(ctx, 180*time.Second)
+	defer cancel()
+
+	frontend := rpmFrontend()
+	if frontend == "" {
+		return "", "", 1, "dnf or yum is required for RPM update checks"
+	}
+
+	type Up struct {
+		Name             string `json:"name"`
+		InstalledVersion string `json:"installed_version,omitempty"`
+		CandidateVersion string `json:"candidate_version,omitempty"`
+		IsSecurity       bool   `json:"is_security,omitempty"`
+	}
+
+	out := struct {
+		CheckedAt      string `json:"checked_at"`
+		RebootRequired bool   `json:"reboot_required"`
+		Updates        []Up   `json:"updates"`
+	}{
+		CheckedAt:      time.Now().UTC().Format(time.RFC3339),
+		RebootRequired: false,
+		Updates:        []Up{},
+	}
+
+	args := []string{"check-update", "-q"}
+	if refresh {
+		args = append([]string{"--refresh"}, args...)
+	}
+	cmd := exec.CommandContext(queryCtx, frontend, args...)
+	b, err := cmd.CombinedOutput()
+	if err != nil {
+		exit := 1
+		if ee, ok := err.(*exec.ExitError); ok {
+			exit = ee.ExitCode()
+		}
+		// dnf/yum use 100 to mean updates are available.
+		if exit != 100 {
+			return "", string(b), exit, fmt.Sprintf("%s check-update failed: %v", frontend, err)
+		}
+	}
+
+	securityNames := rpmSecurityUpdateNames(queryCtx, frontend)
+	seen := map[string]bool{}
+	for _, line := range strings.Split(strings.ReplaceAll(string(b), "\r\n", "\n"), "\n") {
+		parsed, ok := parseRpmCheckUpdateLine(line)
+		if !ok || seen[parsed.Name] {
+			continue
+		}
+		seen[parsed.Name] = true
+		out.Updates = append(out.Updates, Up{
+			Name:             parsed.Name,
+			InstalledVersion: installedRpmVersion(queryCtx, parsed.Name),
+			CandidateVersion: parsed.CandidateVersion,
+			IsSecurity:       securityNames[parsed.Name],
+		})
+	}
+
+	j, jerr := json.Marshal(out)
+	if jerr != nil {
+		return "", "", 1, fmt.Sprintf("JSON marshal failed: %v", jerr)
+	}
+	return string(j), "", 0, ""
+}
+
 func securityUpdatesFromPro(ctx context.Context) (map[string]string, bool) {
 	// Returns map[package]securityVersion for packages that Pro considers security updates,
 	// plus a reboot-required flag (best-effort).
@@ -1247,6 +1545,9 @@ func isKernelMetaPackage(name string) bool {
 }
 
 func runPkgUpgrade(ctx context.Context, packages []string) (string, string, int, string) {
+	if detectPackageManager() == "rpm" {
+		return runRpmPackageAction(ctx, "upgrade", packages, true)
+	}
 	if len(packages) == 0 {
 		return "", "", 0, ""
 	}
@@ -1272,6 +1573,9 @@ func runPkgUpgrade(ctx context.Context, packages []string) (string, string, int,
 }
 
 func runPkgInstall(ctx context.Context, packages []string) (string, string, int, string) {
+	if detectPackageManager() == "rpm" {
+		return runRpmPackageAction(ctx, "install", packages, true)
+	}
 	// Install specific packages, optionally with explicit versions (e.g. name=1.2.3).
 	if len(packages) == 0 {
 		return "", "", 0, ""
@@ -1302,6 +1606,9 @@ func checkCVE(ctx context.Context, cve string) (string, string, int, string) {
 }
 
 func runDistUpgrade(ctx context.Context) (string, string, int, string) {
+	if detectPackageManager() == "rpm" {
+		return runRpmDistUpgrade(ctx)
+	}
 	// Full upgrade (apt-get dist-upgrade). Higher blast radius, but most reliable for transitions.
 	upgradeCtx, cancel := context.WithTimeout(ctx, 30*time.Minute)
 	defer cancel()
@@ -1342,6 +1649,9 @@ func runDistUpgrade(ctx context.Context) (string, string, int, string) {
 }
 
 func runPkgReinstall(ctx context.Context, packages []string) (string, string, int, string) {
+	if detectPackageManager() == "rpm" {
+		return runRpmPackageAction(ctx, "reinstall", packages, true)
+	}
 	if len(packages) == 0 {
 		return "", "", 0, ""
 	}
@@ -1365,6 +1675,9 @@ func runPkgReinstall(ctx context.Context, packages []string) (string, string, in
 }
 
 func runPkgRemove(ctx context.Context, packages []string) (string, string, int, string) {
+	if detectPackageManager() == "rpm" {
+		return runRpmPackageAction(ctx, "remove", packages, false)
+	}
 	if len(packages) == 0 {
 		return "", "", 0, ""
 	}
@@ -1383,18 +1696,97 @@ func runPkgRemove(ctx context.Context, packages []string) (string, string, int, 
 	return string(out), "", 0, ""
 }
 
+func runRpmMakecache(ctx context.Context, frontend string) ([]byte, error) {
+	cmd := exec.CommandContext(ctx, "sudo", "-n", frontend, "-y", "makecache")
+	return cmd.CombinedOutput()
+}
+
+func runRpmPackageAction(ctx context.Context, action string, packages []string, refresh bool) (string, string, int, string) {
+	if len(packages) == 0 {
+		return "", "", 0, ""
+	}
+	frontend := rpmFrontend()
+	if frontend == "" {
+		return "", "", 1, "dnf or yum is required for RPM package actions"
+	}
+
+	var prefix []byte
+	if refresh {
+		cacheOut, cacheErr := runRpmMakecache(ctx, frontend)
+		prefix = cacheOut
+		if cacheErr != nil {
+			return string(cacheOut), "", 1, fmt.Sprintf("%s makecache failed: %v", frontend, cacheErr)
+		}
+	}
+
+	args := []string{"-n", frontend, "-y", action}
+	args = append(args, packages...)
+	cmd := exec.CommandContext(ctx, "sudo", args...)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		exit := 1
+		if ee, ok := err.(*exec.ExitError); ok {
+			exit = ee.ExitCode()
+		}
+		return string(append(prefix, out...)), "", exit, fmt.Sprintf("%s %s failed: %v", frontend, action, err)
+	}
+	return string(append(prefix, out...)), "", 0, ""
+}
+
+func runRpmDistUpgrade(ctx context.Context) (string, string, int, string) {
+	upgradeCtx, cancel := context.WithTimeout(ctx, 30*time.Minute)
+	defer cancel()
+
+	frontend := rpmFrontend()
+	if frontend == "" {
+		return "", "", 1, "dnf or yum is required for RPM package actions"
+	}
+
+	cacheOut, cacheErr := runRpmMakecache(upgradeCtx, frontend)
+	if cacheErr != nil {
+		return string(cacheOut), "", 1, fmt.Sprintf("%s makecache failed: %v", frontend, cacheErr)
+	}
+
+	cmd := exec.CommandContext(upgradeCtx, "sudo", "-n", frontend, "-y", "upgrade")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		exit := 1
+		if ee, ok := err.(*exec.ExitError); ok {
+			exit = ee.ExitCode()
+		}
+		return string(append(cacheOut, out...)), "", exit, fmt.Sprintf("%s upgrade failed: %v", frontend, err)
+	}
+
+	auto := exec.CommandContext(upgradeCtx, "sudo", "-n", frontend, "-y", "autoremove")
+	autoOut, autoErr := auto.CombinedOutput()
+	if autoErr != nil {
+		combined := append(cacheOut, out...)
+		combined = append(combined, []byte("\n\n[WARN] RPM autoremove failed: ")...)
+		combined = append(combined, []byte(autoErr.Error())...)
+		combined = append(combined, []byte("\n")...)
+		combined = append(combined, autoOut...)
+		return string(combined), "", 0, ""
+	}
+
+	combined := append(cacheOut, out...)
+	combined = append(combined, []byte("\n\n[INFO] RPM autoremove output:\n")...)
+	combined = append(combined, autoOut...)
+	return string(combined), "", 0, ""
+}
+
 func runInventoryNow(ctx context.Context, client *http.Client, serverURL, agentID string, token string) (string, string, int, string) {
 	// Collect and POST inventory immediately, so UI can reflect latest packages/updates on demand.
 	queryCtx, cancel := context.WithTimeout(ctx, 60*time.Second)
 	defer cancel()
 
-	pkgs, err := collectDpkgPackages(queryCtx)
+	pkgs, manager, err := collectPackages(queryCtx)
 	if err != nil {
 		return "", "", 1, fmt.Sprintf("collect packages failed: %v", err)
 	}
 	inv := InventoryPayload{
 		AgentID:         agentID,
 		CollectedAtUnix: time.Now().Unix(),
+		Manager:         manager,
 		Packages:        pkgs,
 	}
 	mustPostJSON(client, serverURL+"/agent/inventory/packages", inv, token)

--- a/agent/cmd/fleet-agent/main.go
+++ b/agent/cmd/fleet-agent/main.go
@@ -1128,33 +1128,44 @@ func queryRpmPkgInfo(ctx context.Context, pkgName string) (string, string, int, 
 	rpmOut, rpmErr := rpmCmd.CombinedOutput()
 	info.Raw["rpm_info"] = string(rpmOut)
 	if rpmErr == nil {
-		for _, line := range strings.Split(string(rpmOut), "\n") {
-			if key, val, ok := strings.Cut(line, ":"); ok {
-				key = strings.TrimSpace(strings.ToLower(key))
-				val = strings.TrimSpace(val)
-				switch key {
-				case "version":
-					info.InstalledVersion = val
-				case "release":
-					if info.InstalledVersion != "" && val != "" {
-						info.InstalledVersion = info.InstalledVersion + "-" + val
-					}
-				case "architecture":
-					info.Architecture = val
-				case "group":
-					info.Section = val
-				case "vendor", "packager":
-					if info.Maintainer == "" {
-						info.Maintainer = val
-					}
-				case "url":
-					info.Homepage = val
-				case "summary":
-					info.Summary = val
-				case "description":
-					info.Description = val
-				}
-			}
+		fields := parseRpmInfoFields(string(rpmOut))
+		info.InstalledVersion = fields["version"]
+		if rel := fields["release"]; info.InstalledVersion != "" && rel != "" {
+			info.InstalledVersion = info.InstalledVersion + "-" + rel
+		}
+		info.Architecture = fields["architecture"]
+		info.Section = fields["group"]
+		if fields["vendor"] != "" {
+			info.Maintainer = fields["vendor"]
+		} else {
+			info.Maintainer = fields["packager"]
+		}
+		info.Homepage = fields["url"]
+		info.Summary = fields["summary"]
+		info.Description = fields["description"]
+	}
+
+	applyCandidateFields := func(fields map[string]string) {
+		if info.CandidateVersion == "" && fields["version"] != "" {
+			info.CandidateVersion = fields["version"]
+		}
+		if rel := fields["release"]; info.CandidateVersion != "" && rel != "" && !strings.Contains(info.CandidateVersion, "-") {
+			info.CandidateVersion = info.CandidateVersion + "-" + rel
+		}
+		if info.Architecture == "" {
+			info.Architecture = fields["arch"]
+		}
+		if info.Architecture == "" {
+			info.Architecture = fields["architecture"]
+		}
+		if info.Summary == "" {
+			info.Summary = fields["summary"]
+		}
+		if info.Description == "" {
+			info.Description = fields["description"]
+		}
+		if info.Homepage == "" {
+			info.Homepage = fields["url"]
 		}
 	}
 
@@ -1162,36 +1173,7 @@ func queryRpmPkgInfo(ctx context.Context, pkgName string) (string, string, int, 
 		dnfCmd := exec.CommandContext(ctx, frontend, "info", pkgName)
 		dnfOut, _ := dnfCmd.CombinedOutput()
 		info.Raw[frontend+"_info"] = string(dnfOut)
-		for _, line := range strings.Split(string(dnfOut), "\n") {
-			if key, val, ok := strings.Cut(line, ":"); ok {
-				key = strings.TrimSpace(strings.ToLower(key))
-				val = strings.TrimSpace(val)
-				switch key {
-				case "available packages":
-					continue
-				case "version":
-					if info.CandidateVersion == "" {
-						info.CandidateVersion = val
-					}
-				case "release":
-					if info.CandidateVersion != "" && val != "" && !strings.Contains(info.CandidateVersion, "-") {
-						info.CandidateVersion = info.CandidateVersion + "-" + val
-					}
-				case "arch":
-					if info.Architecture == "" {
-						info.Architecture = val
-					}
-				case "summary":
-					if info.Summary == "" {
-						info.Summary = val
-					}
-				case "url":
-					if info.Homepage == "" {
-						info.Homepage = val
-					}
-				}
-			}
-		}
+		applyCandidateFields(parseRpmInfoFields(string(dnfOut)))
 	}
 
 	j, err := json.Marshal(info)
@@ -1199,6 +1181,55 @@ func queryRpmPkgInfo(ctx context.Context, pkgName string) (string, string, int, 
 		return "", "", 1, fmt.Sprintf("JSON marshal failed: %v", err)
 	}
 	return string(j), "", 0, ""
+}
+
+func isKnownRpmInfoKey(key string) bool {
+	switch key {
+	case "name", "epoch", "version", "release", "architecture", "arch", "install date", "group", "size", "license", "signature", "source rpm", "build date", "build host", "packager", "vendor", "url", "summary", "description", "repository", "from repo":
+		return true
+	default:
+		return false
+	}
+}
+
+func parseRpmInfoFields(out string) map[string]string {
+	fields := map[string]string{}
+	inDesc := false
+	var descLines []string
+
+	for _, raw := range strings.Split(strings.ReplaceAll(out, "\r\n", "\n"), "\n") {
+		line := strings.TrimRight(raw, "\r")
+		if keyRaw, valRaw, ok := strings.Cut(line, ":"); ok {
+			key := strings.TrimSpace(strings.ToLower(keyRaw))
+			val := strings.TrimSpace(valRaw)
+			if inDesc && key != "description" && !isKnownRpmInfoKey(key) {
+				descLines = append(descLines, strings.TrimSpace(line))
+				continue
+			}
+			if key == "description" {
+				inDesc = true
+				if val != "" {
+					descLines = append(descLines, val)
+				}
+				continue
+			}
+			if isKnownRpmInfoKey(key) {
+				inDesc = false
+				if val != "" {
+					fields[key] = val
+				}
+				continue
+			}
+		}
+		if inDesc {
+			descLines = append(descLines, strings.TrimSpace(line))
+		}
+	}
+
+	if len(descLines) > 0 {
+		fields["description"] = strings.TrimSpace(strings.Join(descLines, "\n"))
+	}
+	return fields
 }
 
 func queryPkgUpdates(ctx context.Context, refresh bool) (string, string, int, string) {

--- a/agent/cmd/fleet-agent/main.go
+++ b/agent/cmd/fleet-agent/main.go
@@ -1910,6 +1910,62 @@ func parsePasswdStatusAll(output string) map[string]string {
 	return m
 }
 
+func parseGroupMembers(output string) map[string]bool {
+	members := make(map[string]bool)
+	for _, line := range strings.Split(strings.TrimSpace(output), "\n") {
+		parts := strings.Split(strings.TrimSpace(line), ":")
+		if len(parts) < 4 {
+			continue
+		}
+		for _, member := range strings.Split(parts[3], ",") {
+			member = strings.TrimSpace(member)
+			if member != "" {
+				members[member] = true
+			}
+		}
+	}
+	return members
+}
+
+func parseUserGroups(output string) map[string]bool {
+	groups := make(map[string]bool)
+	for _, group := range strings.Fields(output) {
+		groups[group] = true
+	}
+	return groups
+}
+
+func hasAnyNamedGroup(groups map[string]bool, names ...string) bool {
+	for _, name := range names {
+		if groups[name] {
+			return true
+		}
+	}
+	return false
+}
+
+func userHasSudoAccess(ctx context.Context, username string, sudoGroupUsers map[string]bool) bool {
+	if sudoGroupUsers[username] {
+		return true
+	}
+	if _, statErr := os.Stat(fmt.Sprintf("/etc/sudoers.d/fleet-%s", username)); statErr == nil {
+		return true
+	}
+
+	idCmd := exec.CommandContext(ctx, "id", "-nG", username)
+	if out, err := idCmd.Output(); err == nil {
+		if hasAnyNamedGroup(parseUserGroups(string(out)), "sudo", "wheel", "admin") {
+			return true
+		}
+	}
+
+	sudoCmd := exec.CommandContext(ctx, "sudo", "-n", "-l", "-U", username)
+	if _, err := sudoCmd.CombinedOutput(); err == nil {
+		return true
+	}
+	return false
+}
+
 func queryUsers(ctx context.Context) (string, string, int, string) {
 	// Create a context with timeout to prevent hanging
 	queryCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
@@ -1936,15 +1992,8 @@ func queryUsers(ctx context.Context) (string, string, int, string) {
 	sudoGroupUsers := make(map[string]bool)
 	sudoGroupCmd := exec.CommandContext(queryCtx, "getent", "group", "sudo")
 	if sudoGroupOut, err := sudoGroupCmd.Output(); err == nil {
-		// Parse: sudo:x:27:user1,user2,user3
-		parts := strings.Split(strings.TrimSpace(string(sudoGroupOut)), ":")
-		if len(parts) >= 4 {
-			members := strings.Split(parts[3], ",")
-			for _, member := range members {
-				if member != "" {
-					sudoGroupUsers[member] = true
-				}
-			}
+		for member := range parseGroupMembers(string(sudoGroupOut)) {
+			sudoGroupUsers[member] = true
 		}
 	}
 
@@ -1964,14 +2013,8 @@ func queryUsers(ctx context.Context) (string, string, int, string) {
 	for _, groupName := range []string{"wheel", "admin"} {
 		groupCmd := exec.CommandContext(queryCtx, "getent", "group", groupName)
 		if groupOut, err := groupCmd.Output(); err == nil {
-			parts := strings.Split(strings.TrimSpace(string(groupOut)), ":")
-			if len(parts) >= 4 {
-				members := strings.Split(parts[3], ",")
-				for _, member := range members {
-					if member != "" {
-						sudoGroupUsers[member] = true
-					}
-				}
+			for member := range parseGroupMembers(string(groupOut)) {
+				sudoGroupUsers[member] = true
 			}
 		}
 	}
@@ -1989,16 +2032,7 @@ func queryUsers(ctx context.Context) (string, string, int, string) {
 		home := parts[5]
 		shell := parts[6]
 
-		// Check if user has sudo access.
-		// Prefer fast group-based detection, but also account for Fleet-managed per-user sudoers
-		// entries (/etc/sudoers.d/fleet-<username>) because those can grant sudo even when the
-		// user is not in sudo/wheel/admin groups.
-		hasSudo := sudoGroupUsers[username]
-		if !hasSudo {
-			if _, statErr := os.Stat(fmt.Sprintf("/etc/sudoers.d/fleet-%s", username)); statErr == nil {
-				hasSudo = true
-			}
-		}
+		hasSudo := userHasSudoAccess(queryCtx, username, sudoGroupUsers)
 
 		// "Locked" should reflect practical login-blocking state for SSH/user presence.
 		// Password lock alone (status=L) is not sufficient because SSH key auth can still work.

--- a/agent/cmd/fleet-agent/main.go
+++ b/agent/cmd/fleet-agent/main.go
@@ -102,7 +102,7 @@ func main() {
 		AgentID:   cfg.AgentID,
 		Hostname:  hostname,
 		Labels:    cfg.Labels,
-		OSID:      "ubuntu",
+		OSID:      readOSID(),
 		OSVersion: readOSVersion(),
 		Kernel:    readKernel(),
 	}
@@ -1819,17 +1819,31 @@ func runInventoryNow(ctx context.Context, client *http.Client, serverURL, agentI
 	return string(b), "", 0, ""
 }
 
-func readOSVersion() string {
+func parseOSReleaseValue(content, key string) string {
+	prefix := key + "="
+	for _, line := range strings.Split(content, "\n") {
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, prefix) {
+			return strings.Trim(strings.TrimSpace(line[len(prefix):]), "\"")
+		}
+	}
+	return ""
+}
+
+func readOSReleaseValue(key string) string {
 	b, err := os.ReadFile("/etc/os-release")
 	if err != nil {
 		return ""
 	}
-	for _, line := range strings.Split(string(b), "\n") {
-		if strings.HasPrefix(line, "VERSION_ID=") {
-			return strings.Trim(line[len("VERSION_ID="):], "\"")
-		}
-	}
-	return ""
+	return parseOSReleaseValue(string(b), key)
+}
+
+func readOSID() string {
+	return readOSReleaseValue("ID")
+}
+
+func readOSVersion() string {
+	return readOSReleaseValue("VERSION_ID")
 }
 
 func readKernel() string {

--- a/agent/cmd/fleet-agent/main.go
+++ b/agent/cmd/fleet-agent/main.go
@@ -91,6 +91,10 @@ type JobEvent struct {
 }
 
 func main() {
+	if internal.RunTerminalSSHLoginFromArgs(os.Args) {
+		return
+	}
+
 	log.Println("Fleet agent starting...")
 	go internal.StartTerminalServer()
 

--- a/agent/cmd/fleet-agent/main_test.go
+++ b/agent/cmd/fleet-agent/main_test.go
@@ -172,3 +172,13 @@ func TestParseRpmCheckUpdateLine(t *testing.T) {
 		t.Fatal("metadata line should be ignored")
 	}
 }
+
+func TestParseOSReleaseValue(t *testing.T) {
+	content := "NAME=\"Red Hat Enterprise Linux\"\nID=\"rhel\"\nVERSION_ID=\"9.8\"\n"
+	if got := parseOSReleaseValue(content, "ID"); got != "rhel" {
+		t.Fatalf("ID = %q, want rhel", got)
+	}
+	if got := parseOSReleaseValue(content, "VERSION_ID"); got != "9.8" {
+		t.Fatalf("VERSION_ID = %q, want 9.8", got)
+	}
+}

--- a/agent/cmd/fleet-agent/main_test.go
+++ b/agent/cmd/fleet-agent/main_test.go
@@ -182,3 +182,24 @@ func TestParseOSReleaseValue(t *testing.T) {
 		t.Fatalf("VERSION_ID = %q, want 9.8", got)
 	}
 }
+
+func TestParseRpmInfoFieldsCapturesMultilineDescription(t *testing.T) {
+	out := "" +
+		"Name        : abattis-cantarell-fonts\n" +
+		"Version     : 0.301\n" +
+		"Release     : 4.el9\n" +
+		"Architecture: noarch\n" +
+		"Summary     : Humanist sans serif font\n" +
+		"Description :\n" +
+		"Cantarell is a humanist sans serif font family.\n" +
+		"It is used by GNOME and related desktop components.\n"
+
+	fields := parseRpmInfoFields(out)
+	if fields["summary"] != "Humanist sans serif font" {
+		t.Fatalf("summary = %q", fields["summary"])
+	}
+	wantDesc := "Cantarell is a humanist sans serif font family.\nIt is used by GNOME and related desktop components."
+	if fields["description"] != wantDesc {
+		t.Fatalf("description = %q, want %q", fields["description"], wantDesc)
+	}
+}

--- a/agent/cmd/fleet-agent/main_test.go
+++ b/agent/cmd/fleet-agent/main_test.go
@@ -43,6 +43,26 @@ func TestParsePasswdStatusAll(t *testing.T) {
 	}
 }
 
+func TestParseGroupMembers(t *testing.T) {
+	members := parseGroupMembers("wheel:x:10:imre,deploy\n")
+	if !members["imre"] || !members["deploy"] {
+		t.Fatalf("group members = %#v, want imre and deploy", members)
+	}
+	if members[""] {
+		t.Fatalf("empty member should not be recorded: %#v", members)
+	}
+}
+
+func TestParseUserGroupsAndNamedGroupMatch(t *testing.T) {
+	groups := parseUserGroups("imre wheel docker")
+	if !hasAnyNamedGroup(groups, "sudo", "wheel", "admin") {
+		t.Fatalf("groups = %#v, want wheel sudo match", groups)
+	}
+	if hasAnyNamedGroup(groups, "sudo", "admin") {
+		t.Fatalf("groups = %#v, should not match sudo/admin", groups)
+	}
+}
+
 func TestNormalizeSudoProfile(t *testing.T) {
 	cases := map[string]string{
 		"":         "B",

--- a/agent/cmd/fleet-agent/main_test.go
+++ b/agent/cmd/fleet-agent/main_test.go
@@ -148,3 +148,27 @@ func TestServiceInventoryEnabledFalseWhenServiceAndSocketDisabled(t *testing.T) 
 		t.Fatal("ssh inventory enabled = true, want false when service and socket are disabled")
 	}
 }
+
+func TestSplitRpmNameArch(t *testing.T) {
+	name, arch := splitRpmNameArch("openssl-libs.x86_64")
+	if name != "openssl-libs" || arch != "x86_64" {
+		t.Fatalf("splitRpmNameArch returned %q/%q", name, arch)
+	}
+	name, arch = splitRpmNameArch("python3.11.noarch")
+	if name != "python3.11" || arch != "noarch" {
+		t.Fatalf("splitRpmNameArch with dotted name returned %q/%q", name, arch)
+	}
+}
+
+func TestParseRpmCheckUpdateLine(t *testing.T) {
+	got, ok := parseRpmCheckUpdateLine("openssl-libs.x86_64 1:3.2.2-6.el9_5 baseos")
+	if !ok {
+		t.Fatal("parseRpmCheckUpdateLine returned ok=false")
+	}
+	if got.Name != "openssl-libs" || got.Arch != "x86_64" || got.CandidateVersion != "1:3.2.2-6.el9_5" {
+		t.Fatalf("parsed RPM update = %#v", got)
+	}
+	if _, ok := parseRpmCheckUpdateLine("Last metadata expiration check: 0:03:12 ago"); ok {
+		t.Fatal("metadata line should be ignored")
+	}
+}

--- a/agent/internal/cve.go
+++ b/agent/internal/cve.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/exec"
 	"regexp"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -33,10 +34,10 @@ func CheckCVE(ctx context.Context, cve string) (string, string, int, string) {
 
 	// Always ask Fleet Server (Fast, Offline)
 	jsonResp, rawResp, code, errStr := checkCVEViaFleetServer(ctx, cve)
-	
+
 	// If server is down or returns error, we simply fail/report error.
 	// We do NOT fallback to external 'pro fix'.
-	
+
 	return jsonResp, rawResp, code, errStr
 }
 
@@ -50,15 +51,10 @@ func checkCVEViaFleetServer(ctx context.Context, cve string) (string, string, in
 	}
 	serverURL = strings.TrimRight(serverURL, "/")
 
-	// Determine codename
-	codename := readOSRelease("VERSION_CODENAME")
-	if codename == "" {
-		codename = readOSRelease("UBUNTU_CODENAME")
-	}
-	codename = strings.TrimSpace(strings.ToLower(codename))
+	releaseKey := cveReleaseKey()
 
-	url := fmt.Sprintf("%s/patching/cve/%s?distro_codename=%s", serverURL, cve, codename)
-	
+	url := fmt.Sprintf("%s/patching/cve/%s?distro_codename=%s", serverURL, cve, releaseKey)
+
 	req, _ := http.NewRequestWithContext(ctx2, "GET", url, nil)
 	// Add token if available
 	token := os.Getenv("FLEET_AGENT_TOKEN")
@@ -86,26 +82,34 @@ func checkCVEViaFleetServer(ctx context.Context, cve string) (string, string, in
 	}
 
 	// result: { "cve": "...", "found": true, "distro_found": true, "data": { "packages": {...} } }
-	
+
 	affected := false
 	summary := "unknown"
 	pkgs := []string{}
-	
-	if found, _ := result["found"].(bool); !found {
+
+	found, _ := result["found"].(bool)
+	distroFound, _ := result["distro_found"].(bool)
+	if !found {
+		if detectPackageManager() == "rpm" {
+			return checkRpmCVEViaUpdateinfo(ctx, cve)
+		}
 		summary = "unknown (not in db)"
-	} else if distroFound, _ := result["distro_found"].(bool); !distroFound {
+	} else if !distroFound {
+		if detectPackageManager() == "rpm" {
+			return checkRpmCVEViaUpdateinfo(ctx, cve)
+		}
 		summary = "not affected (distro mismatch)"
 	} else {
 		data, _ := result["data"].(map[string]any)
 		if data != nil {
 			packages, _ := data["packages"].(map[string]any)
-			
+
 			// Filter: Only report packages that are actually installed AND older than fixed version
 			installedPkgs := getInstalledPackages()
-			
+
 			for p, statusRaw := range packages {
 				// Status in DB might be a version string OR a status code (e.g. 'needed', 'DNE')
-				
+
 				neededVer := ""
 				switch v := statusRaw.(type) {
 				case string:
@@ -174,10 +178,77 @@ func readOSRelease(key string) string {
 	return ""
 }
 
+func readOSReleaseMap() map[string]string {
+	b, err := os.ReadFile("/etc/os-release")
+	if err != nil {
+		return map[string]string{}
+	}
+	out := map[string]string{}
+	for _, line := range strings.Split(string(b), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		k, v, ok := strings.Cut(line, "=")
+		if !ok {
+			continue
+		}
+		v = strings.Trim(strings.TrimSpace(v), "\"")
+		out[strings.TrimSpace(k)] = v
+	}
+	return out
+}
+
+func cveReleaseKey() string {
+	osr := readOSReleaseMap()
+	codename := strings.TrimSpace(strings.ToLower(osr["VERSION_CODENAME"]))
+	if codename == "" {
+		codename = strings.TrimSpace(strings.ToLower(osr["UBUNTU_CODENAME"]))
+	}
+	if codename != "" {
+		return codename
+	}
+	id := strings.TrimSpace(strings.ToLower(osr["ID"]))
+	version := strings.TrimSpace(strings.ToLower(osr["VERSION_ID"]))
+	version = strings.Trim(version, "\"")
+	if version != "" {
+		if major, _, ok := strings.Cut(version, "."); ok {
+			version = major
+		}
+	}
+	if id != "" && version != "" {
+		return id + "-" + version
+	}
+	if id != "" {
+		return id
+	}
+	return ""
+}
+
+func detectPackageManager() string {
+	if _, err := exec.LookPath("dpkg-query"); err == nil {
+		return "dpkg"
+	}
+	if _, err := exec.LookPath("rpm"); err == nil {
+		return "rpm"
+	}
+	return ""
+}
+
+func rpmFrontend() string {
+	if _, err := exec.LookPath("dnf"); err == nil {
+		return "dnf"
+	}
+	if _, err := exec.LookPath("yum"); err == nil {
+		return "yum"
+	}
+	return ""
+}
+
 func extractAptPackagesFromProDryRun(out string) []string {
-    // Unused if pro fix is disabled, but kept for compilation safety or future use
+	// Unused if pro fix is disabled, but kept for compilation safety or future use
 	out = strings.ReplaceAll(out, "\r\n", "\n")
-	out = strings.ReplaceAll(out, "\\\n", " ") 
+	out = strings.ReplaceAll(out, "\\\n", " ")
 
 	seen := map[string]bool{}
 	pkgs := make([]string, 0, 8)
@@ -214,16 +285,19 @@ func extractAptPackagesFromProDryRun(out string) []string {
 }
 
 func getInstalledPackages() map[string]string {
+	if detectPackageManager() == "rpm" {
+		return getInstalledRpmPackages()
+	}
 	// dpkg-query -W -f='${Package} ${Version} ${Status}\n'
 	// Returns map of pkg_name -> installed_version
 	// Filters out packages that are not installed (e.g. status='deinstall ok config-files')
-	
+
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
 	cmd := exec.CommandContext(ctx, "dpkg-query", "-W", "-f=${Package} ${Version} ${Status}\n")
 	out, err := cmd.Output()
-	
+
 	res := make(map[string]string)
 	if err != nil {
 		return res
@@ -239,15 +313,40 @@ func getInstalledPackages() map[string]string {
 		if len(parts) >= 4 {
 			// Status field usually has 3 parts: "install ok installed"
 			// rc status: "deinstall ok config-files"
-			
+
 			// We only want packages that are "installed"
 			// The 3rd word in status is the key: "installed" vs "config-files" vs "half-installed"
-			
+
 			status := parts[len(parts)-1] // last part is status-status
-			
+
 			if status == "installed" {
 				res[parts[0]] = parts[1]
 			}
+		}
+	}
+	return res
+}
+
+func getInstalledRpmPackages() map[string]string {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "rpm", "-qa", "--qf", "%{NAME} %{VERSION}-%{RELEASE}\n")
+	out, err := cmd.Output()
+
+	res := make(map[string]string)
+	if err != nil {
+		return res
+	}
+
+	for _, l := range strings.Split(string(out), "\n") {
+		l = strings.TrimSpace(l)
+		if l == "" {
+			continue
+		}
+		parts := strings.Fields(l)
+		if len(parts) >= 2 {
+			res[parts[0]] = parts[1]
 		}
 	}
 	return res
@@ -257,24 +356,96 @@ func isVersionAffected(current, needed string) bool {
 	needed = strings.TrimSpace(needed)
 	if needed == "" || needed == "released" || needed == "needed" {
 		// If DB just says 'released' without a version, we assume affected if installed.
-		return true 
+		return true
 	}
 	if needed == "not-affected" || needed == "DNE" {
 		return false
 	}
-	
+
+	if detectPackageManager() == "rpm" {
+		return isRpmVersionLess(current, needed)
+	}
+
 	// Compare versions: `dpkg --compare-versions current lt needed`
 	// Return true if current < needed (meaning we are older/vulnerable)
-	
+
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
-	
+
 	cmd := exec.CommandContext(ctx, "dpkg", "--compare-versions", current, "lt", needed)
 	if err := cmd.Run(); err == nil {
 		// Exit code 0 means condition is true (current < needed)
 		return true
 	}
 	return false
+}
+
+func isRpmVersionLess(current, needed string) bool {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	expr := fmt.Sprintf("%%{lua:print(rpm.vercmp(%q,%q))}", current, needed)
+	cmd := exec.CommandContext(ctx, "rpm", "--eval", expr)
+	out, err := cmd.Output()
+	if err != nil {
+		return false
+	}
+	cmp, err := strconv.Atoi(strings.TrimSpace(string(out)))
+	return err == nil && cmp < 0
+}
+
+func checkRpmCVEViaUpdateinfo(ctx context.Context, cve string) (string, string, int, string) {
+	frontend := rpmFrontend()
+	if frontend == "" {
+		return "", "", 1, "dnf or yum is required for RPM CVE checks"
+	}
+
+	ctx2, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx2, frontend, "updateinfo", "list", "--cve", cve)
+	out, err := cmd.CombinedOutput()
+	text := strings.TrimSpace(string(out))
+	if err != nil && text == "" {
+		return "", "", 1, fmt.Sprintf("%s updateinfo CVE check failed: %v", frontend, err)
+	}
+
+	installed := getInstalledRpmPackages()
+	pkgs := []string{}
+	seen := map[string]bool{}
+	for _, line := range strings.Split(strings.ReplaceAll(text, "\r\n", "\n"), "\n") {
+		for _, token := range strings.Fields(line) {
+			token = strings.TrimSpace(token)
+			for name, version := range installed {
+				if seen[name] {
+					continue
+				}
+				if token == name || strings.HasPrefix(token, name+"-") || strings.HasPrefix(token, name+".") {
+					seen[name] = true
+					pkgs = append(pkgs, fmt.Sprintf("%s (installed:%s)", name, version))
+				}
+			}
+		}
+	}
+
+	affected := len(pkgs) > 0
+	summary := "not affected (no matching RPM updateinfo)"
+	if affected {
+		summary = "affected"
+	}
+	payload := map[string]any{
+		"cve":      cve,
+		"affected": affected,
+		"summary":  summary,
+		"source":   frontend + "-updateinfo",
+		"packages": pkgs,
+		"details": map[string]any{
+			"release": cveReleaseKey(),
+			"raw":     text,
+		},
+	}
+	j, _ := json.Marshal(payload)
+	return string(j), "", 0, ""
 }
 
 func _bytesTrim(b []byte) []byte { return bytes.TrimSpace(b) }

--- a/agent/internal/terminal.go
+++ b/agent/internal/terminal.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
+	"strings"
 
 	"github.com/creack/pty"
 	"github.com/gorilla/websocket"
@@ -39,14 +40,55 @@ func commandPath(candidates ...string) string {
 	return ""
 }
 
+func osReleaseID() string {
+	b, err := os.ReadFile("/etc/os-release")
+	if err != nil {
+		return ""
+	}
+	for _, line := range strings.Split(string(b), "\n") {
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, "ID=") {
+			return strings.Trim(strings.TrimSpace(strings.TrimPrefix(line, "ID=")), "\"")
+		}
+	}
+	return ""
+}
+
+func prefersSSHConsoleBackend() bool {
+	backend := strings.ToLower(strings.TrimSpace(getenv("FLEET_TERMINAL_BACKEND", "auto")))
+	if backend == "ssh" {
+		return true
+	}
+	if backend == "login" {
+		return false
+	}
+	switch strings.ToLower(osReleaseID()) {
+	case "rhel", "redhat", "rocky", "almalinux", "centos", "fedora":
+		return true
+	default:
+		return false
+	}
+}
+
 func loginCommand() *exec.Cmd {
 	loginPath := commandPath("/bin/login", "/usr/bin/login", "login")
 	agettyPath := commandPath("/sbin/agetty", "/usr/sbin/agetty", "agetty")
+	sshPath := commandPath("/usr/bin/ssh", "/bin/ssh", "ssh")
 	if loginPath == "" {
 		loginPath = "/bin/login"
 	}
 
 	if os.Geteuid() == 0 {
+		if agettyPath != "" && sshPath != "" && prefersSSHConsoleBackend() {
+			return exec.Command(
+				agettyPath,
+				"--noclear",
+				"--login-program", sshPath,
+				"--login-options", "-tt -o LogLevel=ERROR -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o PreferredAuthentications=keyboard-interactive,password -o PubkeyAuthentication=no \\u@localhost",
+				"-",
+				"xterm",
+			)
+		}
 		if agettyPath != "" {
 			return exec.Command(agettyPath, "--noclear", "--login-program", loginPath, "-", "xterm")
 		}

--- a/agent/internal/terminal.go
+++ b/agent/internal/terminal.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"log"
+	"net"
 	"net/http"
 	"os"
 	"os/exec"
@@ -73,21 +74,22 @@ func prefersSSHConsoleBackend() bool {
 func loginCommand() *exec.Cmd {
 	loginPath := commandPath("/bin/login", "/usr/bin/login", "login")
 	agettyPath := commandPath("/sbin/agetty", "/usr/sbin/agetty", "agetty")
-	sshPath := commandPath("/usr/bin/ssh", "/bin/ssh", "ssh")
 	if loginPath == "" {
 		loginPath = "/bin/login"
 	}
 
 	if os.Geteuid() == 0 {
-		if agettyPath != "" && sshPath != "" && prefersSSHConsoleBackend() {
-			return exec.Command(
-				agettyPath,
-				"--noclear",
-				"--login-program", sshPath,
-				"--login-options", "-tt -o LogLevel=ERROR -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o PreferredAuthentications=keyboard-interactive,password -o PubkeyAuthentication=no \\u@localhost",
-				"-",
-				"xterm",
-			)
+		if agettyPath != "" && prefersSSHConsoleBackend() {
+			if self, err := os.Executable(); err == nil && self != "" {
+				return exec.Command(
+					agettyPath,
+					"--noclear",
+					"--login-program", self,
+					"--login-options", "terminal-ssh-login \\u",
+					"-",
+					"xterm",
+				)
+			}
 		}
 		if agettyPath != "" {
 			return exec.Command(agettyPath, "--noclear", "--login-program", loginPath, "-", "xterm")
@@ -98,6 +100,84 @@ func loginCommand() *exec.Cmd {
 		return exec.Command("sudo", "-n", agettyPath, "--noclear", "--login-program", loginPath, "-", "xterm")
 	}
 	return exec.Command("sudo", "-n", loginPath)
+}
+
+func terminalSSHTarget() string {
+	if target := strings.TrimSpace(os.Getenv("FLEET_TERMINAL_SSH_HOST")); target != "" {
+		return target
+	}
+	ifaces, err := net.Interfaces()
+	if err == nil {
+		for _, iface := range ifaces {
+			if iface.Flags&net.FlagUp == 0 || iface.Flags&net.FlagLoopback != 0 {
+				continue
+			}
+			addrs, err := iface.Addrs()
+			if err != nil {
+				continue
+			}
+			for _, addr := range addrs {
+				var ip net.IP
+				switch v := addr.(type) {
+				case *net.IPNet:
+					ip = v.IP
+				case *net.IPAddr:
+					ip = v.IP
+				}
+				if ip == nil || ip.IsLoopback() {
+					continue
+				}
+				if v4 := ip.To4(); v4 != nil {
+					return v4.String()
+				}
+			}
+		}
+	}
+	return "127.0.0.1"
+}
+
+func terminalSSHCommand(username string) *exec.Cmd {
+	sshPath := commandPath("/usr/bin/ssh", "/bin/ssh", "ssh")
+	if sshPath == "" {
+		sshPath = "ssh"
+	}
+	return exec.Command(
+		sshPath,
+		"-tt",
+		"-o", "LogLevel=ERROR",
+		"-o", "StrictHostKeyChecking=no",
+		"-o", "UserKnownHostsFile=/dev/null",
+		"-o", "PreferredAuthentications=password,keyboard-interactive",
+		"-o", "PubkeyAuthentication=no",
+		"-o", "NumberOfPasswordPrompts=3",
+		username+"@"+terminalSSHTarget(),
+	)
+}
+
+func RunTerminalSSHLoginFromArgs(args []string) bool {
+	if len(args) < 2 || args[1] != "terminal-ssh-login" {
+		return false
+	}
+	if len(args) < 3 {
+		os.Exit(2)
+	}
+	username := strings.TrimSpace(args[2])
+	if username == "" || strings.HasPrefix(username, "-") || strings.ContainsAny(username, "\x00\r\n") {
+		os.Exit(2)
+	}
+
+	cmd := terminalSSHCommand(username)
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			os.Exit(exitErr.ExitCode())
+		}
+		os.Exit(1)
+	}
+	os.Exit(0)
+	return true
 }
 
 func StartTerminalServer() {

--- a/agent/internal/terminal.go
+++ b/agent/internal/terminal.go
@@ -24,6 +24,40 @@ var upgrader = websocket.Upgrader{
 	CheckOrigin: func(r *http.Request) bool { return true },
 }
 
+func commandPath(candidates ...string) string {
+	for _, candidate := range candidates {
+		if candidate == "" {
+			continue
+		}
+		if _, err := os.Stat(candidate); err == nil {
+			return candidate
+		}
+		if path, err := exec.LookPath(candidate); err == nil {
+			return path
+		}
+	}
+	return ""
+}
+
+func loginCommand() *exec.Cmd {
+	loginPath := commandPath("/bin/login", "/usr/bin/login", "login")
+	agettyPath := commandPath("/sbin/agetty", "/usr/sbin/agetty", "agetty")
+	if loginPath == "" {
+		loginPath = "/bin/login"
+	}
+
+	if os.Geteuid() == 0 {
+		if agettyPath != "" {
+			return exec.Command(agettyPath, "--noclear", "--login-program", loginPath, "-", "xterm")
+		}
+		return exec.Command(loginPath)
+	}
+	if agettyPath != "" {
+		return exec.Command("sudo", "-n", agettyPath, "--noclear", "--login-program", loginPath, "-", "xterm")
+	}
+	return exec.Command("sudo", "-n", loginPath)
+}
+
 func StartTerminalServer() {
 	// Terminal feature is intentionally opt-in.
 	// Back-compat env var names:
@@ -61,18 +95,13 @@ func StartTerminalServer() {
 		}
 		defer conn.Close()
 
-		// VMware-console style: always present a real login prompt.
-		// If the agent isn't running as root, try via passwordless sudo.
-		var cmd *exec.Cmd
-		if os.Geteuid() == 0 {
-			cmd = exec.Command("/bin/login")
-		} else {
-			cmd = exec.Command("sudo", "-n", "/bin/login")
-		}
+		// VMware-console style: always present a real login prompt. agetty is
+		// preferred because direct login(1) can attach silently on some RHEL PTYs.
+		cmd := loginCommand()
 		ptmx, err := pty.Start(cmd)
 		if err != nil {
 			// Best-effort error to the client before closing.
-			conn.WriteMessage(websocket.TextMessage, []byte("[ERROR] Cannot start login. Ensure agent runs as root or allow sudo NOPASSWD for /bin/login.\r\n"))
+			conn.WriteMessage(websocket.TextMessage, []byte("[ERROR] Cannot start login. Ensure agent runs as root or allow sudo NOPASSWD for login/agetty.\r\n"))
 			return
 		}
 		defer ptmx.Close()

--- a/agent/internal/terminal_test.go
+++ b/agent/internal/terminal_test.go
@@ -1,0 +1,37 @@
+package internal
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestTerminalSSHTargetUsesOverride(t *testing.T) {
+	t.Setenv("FLEET_TERMINAL_SSH_HOST", "192.0.2.10")
+
+	if got := terminalSSHTarget(); got != "192.0.2.10" {
+		t.Fatalf("terminalSSHTarget() = %q, want override", got)
+	}
+}
+
+func TestTerminalSSHCommandUsesResolvedTarget(t *testing.T) {
+	t.Setenv("FLEET_TERMINAL_SSH_HOST", "192.0.2.10")
+
+	cmd := terminalSSHCommand("imre")
+	got := strings.Join(cmd.Args, " ")
+	if !strings.Contains(got, "imre@192.0.2.10") {
+		t.Fatalf("terminalSSHCommand args = %q, want target user@host", got)
+	}
+	if strings.Contains(got, "imre@localhost") {
+		t.Fatalf("terminalSSHCommand args = %q, should not force localhost", got)
+	}
+	if !strings.Contains(got, "NumberOfPasswordPrompts=3") {
+		t.Fatalf("terminalSSHCommand args = %q, want explicit password prompt count", got)
+	}
+}
+
+func TestRunTerminalSSHLoginFromArgsIgnoresNormalAgentStart(t *testing.T) {
+	if RunTerminalSSHLoginFromArgs([]string{os.Args[0]}) {
+		t.Fatal("RunTerminalSSHLoginFromArgs() = true for normal agent args")
+	}
+}

--- a/deploy/sudoers/fleet-agent
+++ b/deploy/sudoers/fleet-agent
@@ -6,9 +6,15 @@ Cmnd_Alias FLEET_APT_REINSTALL = /usr/bin/apt-get -y install --reinstall *
 Cmnd_Alias FLEET_APT_REINSTALL_I = /usr/bin/apt-get install --reinstall *
 Cmnd_Alias FLEET_APT_REMOVE = /usr/bin/apt-get -y remove *
 Cmnd_Alias FLEET_APT_REMOVE_I = /usr/bin/apt-get remove *
+Cmnd_Alias FLEET_DNF_MAKECACHE = /usr/bin/dnf -y makecache, /usr/bin/yum -y makecache
+Cmnd_Alias FLEET_DNF_UPGRADE = /usr/bin/dnf -y upgrade *, /usr/bin/yum -y upgrade *
+Cmnd_Alias FLEET_DNF_INSTALL = /usr/bin/dnf -y install *, /usr/bin/yum -y install *
+Cmnd_Alias FLEET_DNF_REINSTALL = /usr/bin/dnf -y reinstall *, /usr/bin/yum -y reinstall *
+Cmnd_Alias FLEET_DNF_REMOVE = /usr/bin/dnf -y remove *, /usr/bin/yum -y remove *
+Cmnd_Alias FLEET_DNF_AUTOREMOVE = /usr/bin/dnf -y autoremove, /usr/bin/yum -y autoremove
 Cmnd_Alias FLEET_PASSWD = /usr/bin/passwd -S *, /usr/bin/passwd -l *, /usr/bin/passwd -u *
 Cmnd_Alias FLEET_GETENT = /usr/bin/getent shadow *
 Cmnd_Alias FLEET_SYSTEMCTL = /usr/bin/systemctl start *, /usr/bin/systemctl stop *, /usr/bin/systemctl restart *, /usr/bin/systemctl enable *, /usr/bin/systemctl disable *
 Cmnd_Alias FLEET_USERMOD = /usr/sbin/usermod --expiredate *, /usr/sbin/usermod -s *
 
-%fleet-agent ALL=(root) NOPASSWD: FLEET_APT_UPDATE, FLEET_APT_UPGRADE, FLEET_APT_UPGRADE_I, FLEET_APT_REINSTALL, FLEET_APT_REINSTALL_I, FLEET_APT_REMOVE, FLEET_APT_REMOVE_I, FLEET_PASSWD, FLEET_GETENT, FLEET_SYSTEMCTL, FLEET_USERMOD
+%fleet-agent ALL=(root) NOPASSWD: FLEET_APT_UPDATE, FLEET_APT_UPGRADE, FLEET_APT_UPGRADE_I, FLEET_APT_REINSTALL, FLEET_APT_REINSTALL_I, FLEET_APT_REMOVE, FLEET_APT_REMOVE_I, FLEET_DNF_MAKECACHE, FLEET_DNF_UPGRADE, FLEET_DNF_INSTALL, FLEET_DNF_REINSTALL, FLEET_DNF_REMOVE, FLEET_DNF_AUTOREMOVE, FLEET_PASSWD, FLEET_GETENT, FLEET_SYSTEMCTL, FLEET_USERMOD

--- a/script.sh
+++ b/script.sh
@@ -251,6 +251,10 @@ REMOTE_TERMINAL_TOKEN="${TERM_TOKEN:-}"
 if [ -n "$SERVER_URL" ] && [ -n "$REMOTE_AGENT_TOKEN" ]; then
   log_info "Installing/updating fleet-agent systemd service on targets"
 
+  # Stop stray manually launched agents before systemd starts the managed one.
+  ansible "$TARGETS" -i "$ROOT_DIR/hosts" -b "${ANSIBLE_COMMON_ARGS[@]}" -m shell -a "pkill -x fleet-agent || true" \
+    || log_warn "Agent deploy: could not reach some hosts (pre-systemd pkill step)"
+
   # Write env file on the REMOTE host (so hostname is correct)
   ansible "$TARGETS" -i "$ROOT_DIR/hosts" -b "${ANSIBLE_COMMON_ARGS[@]}" -m shell -a "umask 077; HOSTID=\"\$(hostname -s)\"; SERVER_URL=\"$SERVER_URL\"; TOKEN=\"$REMOTE_AGENT_TOKEN\"; TERM_TOKEN=\"$REMOTE_TERMINAL_TOKEN\"; cat > /etc/fleet-agent.env <<EOF
 FLEET_SERVER_URL=\$SERVER_URL
@@ -289,16 +293,16 @@ EOF
 chmod 0644 /etc/systemd/system/fleet-agent.service" \
     || log_warn "Agent deploy: could not reach some hosts (systemd unit step)"
 
+  if [ -n "$REMOTE_TERMINAL_TOKEN" ]; then
+    ansible "$TARGETS" -i "$ROOT_DIR/hosts" -b "${ANSIBLE_COMMON_ARGS[@]}" -m shell -a "if command -v firewall-cmd >/dev/null 2>&1 && systemctl is-active --quiet firewalld; then firewall-cmd --add-port=18080/tcp --permanent && firewall-cmd --reload; fi" \
+      || log_warn "Agent deploy: could not update firewalld for terminal port 18080"
+  fi
+
   ansible "$TARGETS" -i "$ROOT_DIR/hosts" -b "${ANSIBLE_COMMON_ARGS[@]}" -m shell -a "systemctl daemon-reload && systemctl enable --now fleet-agent && systemctl is-active fleet-agent" \
     || log_warn "Agent deploy: could not reach some hosts (systemd enable/restart step)"
 else
   log_warn "SERVER_URL and/or AGENT_TOKEN not set; skipping systemd service setup. Binary copied only."
 fi
-
-# Kill any stray user-run agent instances (to avoid duplicate heartbeats / confusion)
-# (Don't use pkill -f with a pattern that appears in our own command line.)
-ansible "$TARGETS" -i "$ROOT_DIR/hosts" -b "${ANSIBLE_COMMON_ARGS[@]}" -m shell -a "pkill -x fleet-agent || true" \
-  || log_warn "Agent deploy: could not reach some hosts (pkill step)"
 
 AGENT_TOKEN="${AGENT_TOKEN:-}"
 TERM_TOKEN="${TERM_TOKEN:-}"

--- a/server/app/routers/agent.py
+++ b/server/app/routers/agent.py
@@ -91,6 +91,9 @@ def agent_inventory_packages(payload: PackagesInventory, request: Request, db: S
         raise HTTPException(404, "unknown agent")
 
     collected_at = datetime.fromtimestamp(payload.collected_at_unix, tz=timezone.utc)
+    manager = (payload.manager or "dpkg").strip().lower()
+    if manager not in {"dpkg", "rpm"}:
+        manager = "dpkg"
 
     db.execute(delete(HostPackage).where(HostPackage.host_id == host.id))
     db.execute(delete(HostCVEStatus).where(HostCVEStatus.host_id == host.id))
@@ -105,7 +108,7 @@ def agent_inventory_packages(payload: PackagesInventory, request: Request, db: S
                 name=name,
                 version=ver,
                 arch=p.get("arch", "amd64"),
-                manager="dpkg",
+                manager=manager,
                 collected_at=collected_at,
             )
         )

--- a/server/app/routers/search.py
+++ b/server/app/routers/search.py
@@ -9,15 +9,33 @@ from ..deps import require_ui_user
 from ..models import Host, HostCVEStatus, HostPackage, CVEPackage
 from ..services.user_scopes import filter_agent_ids_for_user
 from ..services.deb_version import is_vulnerable
+from ..services.rpm_version import is_vulnerable as is_rpm_vulnerable
 from ..services.rbac import is_admin
 
 router = APIRouter(prefix="/search", tags=["search"])
 
 
+def release_key_for_host(os_id: str | None, os_version: str | None) -> str | None:
+    os_id_norm = (os_id or "").strip().lower()
+    os_ver = (os_version or "").strip().lower()
+    if "20.04" in os_ver or "focal" in os_ver:
+        return "focal"
+    if "22.04" in os_ver or "jammy" in os_ver:
+        return "jammy"
+    if "24.04" in os_ver or "noble" in os_ver:
+        return "noble"
+    if os_id_norm in {"rhel", "redhat", "rocky", "almalinux", "centos", "fedora", "ol", "oracle"}:
+        version = os_ver.split(".", 1)[0].strip()
+        if version:
+            return f"{os_id_norm}-{version}"
+        return os_id_norm
+    return None
+
+
 @router.get("/packages")
 def search_packages(name: str, version: str | None = None, db: Session = Depends(get_db), user=Depends(require_ui_user)):
     stmt = (
-        select(Host.hostname, Host.agent_id, HostPackage.version, HostPackage.arch, Host.os_version)
+        select(Host.hostname, Host.agent_id, HostPackage.version, HostPackage.arch, Host.os_id, Host.os_version, HostPackage.manager)
         .join(HostPackage, Host.id == HostPackage.host_id)
         .where(HostPackage.name == name)
     )
@@ -54,20 +72,16 @@ def search_packages(name: str, version: str | None = None, db: Session = Depends
 
     results = []
     for r in rows:
-        # r = (hostname, agent_id, version, arch, os_version)
         if allowed is not None and r[1] not in allowed:
             continue
             
         cves = []
-        os_ver = (r[4] or "").lower()
-        codename = None
-        if "20.04" in os_ver or "focal" in os_ver: codename = "focal"
-        elif "22.04" in os_ver or "jammy" in os_ver: codename = "jammy"
-        elif "24.04" in os_ver or "noble" in os_ver: codename = "noble"
-        
-        if codename and codename in cve_map:
-            for cve_id, fixed_ver in cve_map[codename]:
-                if is_vulnerable(r[2], fixed_ver):
+        release_key = release_key_for_host(r[4], r[5])
+
+        if release_key and release_key in cve_map:
+            for cve_id, fixed_ver in cve_map[release_key]:
+                vulnerable = is_rpm_vulnerable(r[2], fixed_ver) if (r[6] or "").lower() == "rpm" else is_vulnerable(r[2], fixed_ver)
+                if vulnerable:
                     cves.append(cve_id)
         
         results.append({

--- a/server/app/schemas.py
+++ b/server/app/schemas.py
@@ -13,6 +13,7 @@ class AgentRegister(BaseModel):
 class PackagesInventory(BaseModel):
     agent_id: str
     collected_at_unix: int
+    manager: Optional[str] = None
     packages: List[dict]
 
 class PackageUpdateItem(BaseModel):

--- a/server/app/services/rpm_version.py
+++ b/server/app/services/rpm_version.py
@@ -1,0 +1,63 @@
+import re
+
+
+def _split_epoch(version: str) -> tuple[int, str]:
+    if ":" not in version:
+        return 0, version
+    epoch, rest = version.split(":", 1)
+    try:
+        return int(epoch), rest
+    except ValueError:
+        return 0, rest
+
+
+def _segments(value: str) -> list[str]:
+    return re.findall(r"[A-Za-z]+|\d+|~|\^", value or "")
+
+
+def compare_versions(v1: str, v2: str) -> int:
+    """
+    Small RPM-like version comparator for server-side CVE filtering.
+    Returns -1 when v1 < v2, 0 when equal, 1 when v1 > v2.
+    """
+    e1, rest1 = _split_epoch(v1 or "")
+    e2, rest2 = _split_epoch(v2 or "")
+    if e1 != e2:
+        return -1 if e1 < e2 else 1
+
+    s1 = _segments(rest1)
+    s2 = _segments(rest2)
+    i = 0
+    while i < len(s1) or i < len(s2):
+        a = s1[i] if i < len(s1) else ""
+        b = s2[i] if i < len(s2) else ""
+        if a == b:
+            i += 1
+            continue
+        if a == "~" or b == "^":
+            return -1
+        if b == "~" or a == "^":
+            return 1
+        if not a:
+            return -1
+        if not b:
+            return 1
+        if a.isdigit() and b.isdigit():
+            ai = int(a.lstrip("0") or "0")
+            bi = int(b.lstrip("0") or "0")
+            if ai != bi:
+                return -1 if ai < bi else 1
+            if len(a.lstrip("0")) != len(b.lstrip("0")):
+                return -1 if len(a.lstrip("0")) < len(b.lstrip("0")) else 1
+        elif a.isdigit():
+            return 1
+        elif b.isdigit():
+            return -1
+        else:
+            return -1 if a < b else 1
+        i += 1
+    return 0
+
+
+def is_vulnerable(installed_version: str, fixed_version: str) -> bool:
+    return compare_versions(installed_version, fixed_version) < 0

--- a/server/app/templates/fleet-phase3-host-workflows.js
+++ b/server/app/templates/fleet-phase3-host-workflows.js
@@ -34,15 +34,15 @@
         return `
           <div class="user-card ${isNew ? 'new-user' : ''}" data-username="${w.escapeHtml(user.username)}">
             <div class="user-info">
-              <div class="user-name"><a href="#" class="user-name-link" data-username="${w.escapeHtml(user.username)}" style="text-decoration:underline;">${w.escapeHtml(user.username)}</a>${isNew ? '<span class="new-user-badge">NEW</span>' : ''}</div>
+              <div class="user-name"><a href="#" class="user-name-link" data-username="${w.escapeHtml(user.username)}">${w.escapeHtml(user.username)}</a>${isNew ? '<span class="new-user-badge">NEW</span>' : ''}</div>
               <div class="user-details">
                 UID: ${w.escapeHtml(user.uid)} | GID: ${w.escapeHtml(user.gid)} | Shell: ${w.escapeHtml(user.shell || 'N/A')}${user.home ? ` | Home: ${w.escapeHtml(user.home)}` : ''}
               </div>
-              <div style="margin-top: 0.5rem;">
+              <div class="user-badges">
                 <span class="sudo-badge ${user.has_sudo ? 'yes' : 'no'}">
                   ${user.has_sudo ? '✓ Has Sudo' : '✗ No Sudo'}
                 </span>
-                ${user.is_locked ? '<span class="sudo-badge no" style="margin-left: 0.5rem;">🔒 Locked</span>' : ''}
+                ${user.is_locked ? '<span class="sudo-badge no">Locked</span>' : ''}
               </div>
             </div>
             <div class="service-actions">

--- a/server/app/templates/fleet-ui-v2.css
+++ b/server/app/templates/fleet-ui-v2.css
@@ -691,7 +691,6 @@ body {
 .section-card,
 .overview-card,
 .load-graph-container,
-.user-card,
 .service-card,
 .filter-section,
 .modal-panel {
@@ -704,10 +703,58 @@ body {
 .admin-card,
 .metric-card,
 .load-graph-container,
-.user-card,
 .service-card,
 .filter-section {
   padding: 1rem;
+}
+
+.user-card {
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--panel) 88%, var(--panel-2));
+  box-shadow: none;
+  padding: 1rem;
+}
+
+.user-name-link {
+  color: var(--status-link-text);
+  text-decoration: none;
+}
+
+.user-name-link:hover {
+  text-decoration: underline;
+}
+
+.user-details {
+  color: var(--muted-2);
+}
+
+.user-badges {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  align-items: center;
+}
+
+.user-badges .sudo-badge {
+  margin-top: 0.5rem;
+}
+
+.sudo-badge {
+  border: 1px solid transparent;
+  border-radius: 999px;
+}
+
+.sudo-badge.yes {
+  background: var(--status-ok-bg);
+  color: var(--status-ok-text);
+  border-color: var(--status-ok-border);
+}
+
+.sudo-badge.no {
+  background: var(--pkg-badge-bad-bg);
+  color: var(--pkg-badge-bad-text);
+  border-color: var(--pkg-badge-bad-border);
 }
 
 .admin-card-title {

--- a/server/app/templates/fleet-ui-v2.css
+++ b/server/app/templates/fleet-ui-v2.css
@@ -691,6 +691,7 @@ body {
 .section-card,
 .overview-card,
 .load-graph-container,
+.user-card,
 .service-card,
 .filter-section,
 .modal-panel {
@@ -703,16 +704,9 @@ body {
 .admin-card,
 .metric-card,
 .load-graph-container,
+.user-card,
 .service-card,
 .filter-section {
-  padding: 1rem;
-}
-
-.user-card {
-  border: 1px solid var(--border);
-  border-radius: 8px;
-  background: color-mix(in srgb, var(--panel) 88%, var(--panel-2));
-  box-shadow: none;
   padding: 1rem;
 }
 
@@ -741,8 +735,9 @@ body {
 }
 
 .sudo-badge {
+  padding: 0.2rem 0.55rem;
   border: 1px solid transparent;
-  border-radius: 999px;
+  border-radius: 3px;
 }
 
 .sudo-badge.yes {

--- a/server/app/templates/fleet-ui.css
+++ b/server/app/templates/fleet-ui.css
@@ -1167,14 +1167,15 @@ body {
 
 .user-card,
 .service-card {
-  background: var(--panel);
+  background: color-mix(in srgb, var(--panel) 88%, var(--panel-2));
   border: 1px solid var(--border);
   border-radius: 8px;
   padding: 1rem;
   margin-bottom: 1rem;
   display: flex;
   justify-content: space-between;
-  align-items: center;
+  align-items: flex-start;
+  gap: 1rem;
 }
 
 .user-card.new-user {
@@ -1207,6 +1208,15 @@ body {
   margin-bottom: 0.25rem;
 }
 
+.user-name-link {
+  color: var(--status-link-text);
+  text-decoration: none;
+}
+
+.user-name-link:hover {
+  text-decoration: underline;
+}
+
 .user-details,
 .service-details {
   font-size: 0.875rem;
@@ -1214,22 +1224,38 @@ body {
 }
 
 .sudo-badge {
-  display: inline-block;
-  padding: 0.25rem 0.75rem;
-  border-radius: 12px;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.2rem 0.65rem;
+  border-radius: 999px;
   font-size: 0.75rem;
-  font-weight: 600;
+  font-weight: 700;
   margin-top: 0.5rem;
+  border: 1px solid transparent;
 }
 
 .sudo-badge.yes {
-  background: color-mix(in srgb, var(--success) 18%, transparent);
-  color: color-mix(in srgb, var(--success) 80%, var(--text));
+  background: var(--status-ok-bg);
+  color: var(--status-ok-text);
+  border-color: var(--status-ok-border);
 }
 
 .sudo-badge.no {
-  background: color-mix(in srgb, var(--danger) 18%, transparent);
-  color: color-mix(in srgb, var(--danger) 80%, var(--text));
+  background: var(--pkg-badge-bad-bg);
+  color: var(--pkg-badge-bad-text);
+  border-color: var(--pkg-badge-bad-border);
+}
+
+.user-badges {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  align-items: center;
+}
+
+.user-badges .sudo-badge {
+  margin-top: 0.5rem;
 }
 
 .label-badges {

--- a/server/tests/test_jobs_flow.py
+++ b/server/tests/test_jobs_flow.py
@@ -377,8 +377,9 @@ def test_package_inventory_invalidates_host_cve_cache(monkeypatch):
             json={
                 "agent_id": "srv-inventory-cve",
                 "collected_at_unix": 1_700_000_000,
+                "manager": "rpm",
                 "packages": [
-                    {"name": "libpam-modules", "version": "1.5.3-5ubuntu5.4", "arch": "amd64"},
+                    {"name": "libpam-modules", "version": "1.5.3-5ubuntu5.4", "arch": "x86_64"},
                 ],
             },
         )
@@ -402,6 +403,8 @@ def test_package_inventory_invalidates_host_cve_cache(monkeypatch):
             ).scalar_one_or_none()
             assert package is not None
             assert package.version == "1.5.3-5ubuntu5.4"
+            assert package.arch == "x86_64"
+            assert package.manager == "rpm"
 
 
 def test_cleanup_offline_hosts_admin_only(monkeypatch):

--- a/server/tests/test_rpm_support.py
+++ b/server/tests/test_rpm_support.py
@@ -1,0 +1,12 @@
+from app.routers.search import release_key_for_host
+from app.services.rpm_version import is_vulnerable
+
+
+def test_release_key_for_rpm_hosts():
+    assert release_key_for_host("rocky", "9.4") == "rocky-9"
+    assert release_key_for_host("fedora", "40") == "fedora-40"
+
+
+def test_rpm_version_compare_handles_epoch_and_release():
+    assert is_vulnerable("1:3.2.2-5.el9", "1:3.2.2-6.el9") is True
+    assert is_vulnerable("1:3.2.2-7.el9", "1:3.2.2-6.el9") is False


### PR DESCRIPTION
## Summary
- add RPM package manager detection, inventory, package actions, CVE/update handling, and RPM version comparison
- improve RHEL agent responsiveness, OS reporting, terminal deployment, and SSH-backed console login
- align System Users & Sudo Rights cards/badges with the v2 UI styling

## Validation
- go test ./...
- npm run test:frontend
- server focused tests for RPM/job flow
- git diff --check