### PR TITLE
Fix firewall service-rule UI

### DIFF
--- a/server/app/routers/hosts.py
+++ b/server/app/routers/hosts.py
@@ -1316,6 +1316,8 @@ async def get_firewall(agent_id: str, wait: bool = True, db: Session = Depends(g
     run = res.run
     if run.status == "failed":
         msg = run.error or run.stderr or "Unknown error"
+        if "unknown job type" in msg.lower():
+            raise HTTPException(409, "Firewall query failed: fleet-agent on this host is older and must be redeployed")
         raise HTTPException(500, f"Firewall query failed: {msg}")
 
     from ..services.json_utils import loads_or
@@ -1379,6 +1381,8 @@ async def control_firewall(
     run = res.run
     if run.status == "failed":
         msg = run.error or run.stderr or run.stdout or "Unknown error"
+        if "unknown job type" in msg.lower():
+            raise HTTPException(409, "Firewall action failed: fleet-agent on this host is older and must be redeployed")
         raise HTTPException(500, f"Firewall {rule['action']} failed: {msg}")
 
     return {"job_id": created.job_key, "status": "success"}

--- a/server/app/templates/fleet-phase3-host-workflows.js
+++ b/server/app/templates/fleet-phase3-host-workflows.js
@@ -197,6 +197,7 @@
         const text = formatFirewallRule(rule);
         const port = rule.port || '';
         const protocol = rule.protocol || 'tcp';
+        const service = rule.service || '';
         return `
           <div class="service-card">
             <div class="service-info">
@@ -204,7 +205,7 @@
               <div class="service-details">${w.escapeHtml(rule.raw || '')}</div>
             </div>
             <div class="service-actions">
-              <button class="btn btn-danger" data-firewall-delete="1" data-port="${w.escapeHtml(port)}" data-protocol="${w.escapeHtml(protocol)}" ${(!port || !canManage) ? 'disabled' : ''}>Remove allow</button>
+              <button class="btn btn-danger" data-firewall-delete="1" data-port="${w.escapeHtml(port)}" data-protocol="${w.escapeHtml(protocol)}" data-service="${w.escapeHtml(service)}" ${((!port && !service) || !canManage) ? 'disabled' : ''}>Remove allow</button>
             </div>
           </div>
         `;
@@ -215,8 +216,9 @@
           e.preventDefault();
           const port = Number(btn.getAttribute('data-port') || '0');
           const protocol = btn.getAttribute('data-protocol') || 'tcp';
-          if (!port) return;
-          controlFirewall(ctx, agentId, { action: 'delete', port, protocol });
+          const service = btn.getAttribute('data-service') || '';
+          if (!port && !service) return;
+          controlFirewall(ctx, agentId, { action: 'delete', port, protocol, service });
         });
       });
     } catch (error) {
@@ -229,7 +231,8 @@
     const port = Number(document.getElementById('host-firewall-port')?.value || '0');
     const protocol = document.getElementById('host-firewall-protocol')?.value || 'tcp';
     const source = (document.getElementById('host-firewall-source')?.value || '').trim();
-    return { action, port, protocol, source };
+    const service = (document.getElementById('host-firewall-service')?.value || '').trim();
+    return { action, port, protocol, source, service };
   }
 
   async function controlFirewall(ctx, agentId, payload) {
@@ -238,8 +241,8 @@
       return;
     }
     const statusEl = document.getElementById('host-firewall-status');
-    if (!payload.port || payload.port < 1 || payload.port > 65535) {
-      w.showToast('Enter a valid port', 'error');
+    if (!payload.service && (!payload.port || payload.port < 1 || payload.port > 65535)) {
+      w.showToast('Enter a valid port or service', 'error');
       return;
     }
     try {

--- a/server/app/templates/index.html
+++ b/server/app/templates/index.html
@@ -680,6 +680,10 @@
                 <label style="display:block;color:var(--muted-2);font-size:0.85rem;margin-bottom:0.25rem;">Port</label>
                 <input id="firewall-management-port" class="host-search" type="number" min="1" max="65535" placeholder="443" />
               </div>
+              <div style="min-width:150px;">
+                <label style="display:block;color:var(--muted-2);font-size:0.85rem;margin-bottom:0.25rem;">Service</label>
+                <input id="firewall-management-service" class="host-search" type="text" placeholder="cockpit" />
+              </div>
               <div style="min-width:110px;">
                 <label style="display:block;color:var(--muted-2);font-size:0.85rem;margin-bottom:0.25rem;">Protocol</label>
                 <select id="firewall-management-protocol" class="host-search">
@@ -1341,6 +1345,10 @@
             <div style="min-width:110px;">
               <label style="display:block;color:var(--muted-2);font-size:0.85rem;margin-bottom:0.25rem;">Port</label>
               <input id="host-firewall-port" class="host-search" type="number" min="1" max="65535" placeholder="443" />
+            </div>
+            <div style="min-width:150px;">
+              <label style="display:block;color:var(--muted-2);font-size:0.85rem;margin-bottom:0.25rem;">Service</label>
+              <input id="host-firewall-service" class="host-search" type="text" placeholder="cockpit" />
             </div>
             <div style="min-width:110px;">
               <label style="display:block;color:var(--muted-2);font-size:0.85rem;margin-bottom:0.25rem;">Protocol</label>
@@ -5230,6 +5238,7 @@
       const statusEl = document.getElementById('firewall-management-status');
       const bodyEl = document.getElementById('firewall-management-table-body');
       const portEl = document.getElementById('firewall-management-port');
+      const serviceEl = document.getElementById('firewall-management-service');
       const protoEl = document.getElementById('firewall-management-protocol');
       const sourceEl = document.getElementById('firewall-management-source');
       if (!bodyEl) return;
@@ -5347,18 +5356,20 @@
       async function runFirewallOperation(action) {
         const agentIds = selectedFirewallAgentIds();
         const port = Number(portEl?.value || '0');
+        const service = String(serviceEl?.value || '').trim();
         const protocol = protoEl?.value || 'tcp';
         const source = String(sourceEl?.value || '').trim();
         if (!agentIds.length) {
           if (typeof showToast === 'function') showToast('Select at least one host', 'error');
           return;
         }
-        if (!port || port < 1 || port > 65535) {
-          if (typeof showToast === 'function') showToast('Enter a valid port', 'error');
+        if (!service && (!port || port < 1 || port > 65535)) {
+          if (typeof showToast === 'function') showToast('Enter a valid port or service', 'error');
           return;
         }
         const label = action === 'delete' ? 'Remove allow' : action === 'allow' ? 'Allow' : 'Deny';
-        if (!confirm(`${label} ${port}/${protocol} on ${agentIds.length} selected host(s)?`)) return;
+        const target = service ? `service ${service}` : `${port}/${protocol}`;
+        if (!confirm(`${label} ${target} on ${agentIds.length} selected host(s)?`)) return;
 
         [allowBtn, denyBtn, deleteBtn, refreshBtn].forEach((btn) => { if (btn) btn.disabled = true; });
         try {
@@ -5366,7 +5377,7 @@
           const r = await fetch(`/reports/firewall-rules/${encodeURIComponent(action)}`, {
             method: 'POST',
             headers: { 'content-type': 'application/json' },
-            body: JSON.stringify({ agent_ids: agentIds, port, protocol, source }),
+            body: JSON.stringify({ agent_ids: agentIds, port, protocol, source, service }),
           });
           if (!r.ok) {
             const err = await r.json().catch(() => ({}));


### PR DESCRIPTION
## Summary
- clarify firewall errors when an older agent receives new firewall job types
- add Service fields to host and fleet firewall forms
- allow service-only rules such as cockpit to be removed from the UI

## Tests
- python -m compileall -q server/app
- pytest -q server/tests/test_host_services_routes.py
- npm run test:frontend -- --run server/tests/frontend/host-actions-menu.test.js server/tests/frontend/service-management-navigation.test.js