### PR TITLE
Add urgent updates dashboard panel

### DIFF
--- a/server/app/routers/dashboard.py
+++ b/server/app/routers/dashboard.py
@@ -12,6 +12,7 @@ from ..config import settings
 from ..db import get_db
 from ..deps import require_admin_user, require_ui_user
 from ..models import BackupVerificationPolicy, BackupVerificationRun, Host, HostMetricsSnapshot, HostPackageUpdate, Job, JobRun, NotificationDedupeState, OIDCAuthEvent
+from ..services.cve_reporting import collect_high_severity_findings
 from ..services.db_utils import transaction
 from ..services.jobs import create_job_with_runs, push_job_to_agents
 from ..services.maintenance import is_within_maintenance_window
@@ -19,6 +20,12 @@ from ..services.teams import post_teams_message
 from ..services.user_scopes import is_host_visible_to_user
 
 router = APIRouter(prefix="/dashboard", tags=["dashboard"])
+
+
+def _is_host_online(host: Host, *, now: datetime) -> bool:
+    grace_s = int(getattr(settings, "agent_online_grace_seconds", 10) or 10)
+    online_cutoff = now.timestamp() - grace_s
+    return bool(host.last_seen is not None and host.last_seen.timestamp() >= online_cutoff)
 
 
 @router.get("/summary")
@@ -125,6 +132,139 @@ def dashboard_summary(db: Session = Depends(get_db), user=Depends(require_ui_use
         },
         "jobs": {"failed_runs_last_24h": failed_runs_24h},
         "notes": [],
+    }
+
+
+@router.get("/urgent-updates")
+def dashboard_urgent_updates(
+    db: Session = Depends(get_db),
+    user=Depends(require_ui_user),
+    limit: int = Query(10, ge=1, le=50),
+):
+    """Top hosts that most urgently need patching attention."""
+
+    now = datetime.now(timezone.utc)
+    hosts = [
+        h for h in db.execute(select(Host).order_by(Host.hostname.asc())).scalars().all()
+        if is_host_visible_to_user(db, user, h)
+    ]
+    host_by_id = {h.id: h for h in hosts}
+
+    rows = db.execute(
+        select(
+            HostPackageUpdate.host_id,
+            func.count().label("updates_total"),
+            func.sum(cast(HostPackageUpdate.is_security, Integer)).label("security_total"),
+            func.max(HostPackageUpdate.checked_at).label("checked_at"),
+        )
+        .where(HostPackageUpdate.update_available == True)  # noqa: E712
+        .group_by(HostPackageUpdate.host_id)
+    ).all()
+    update_map = {
+        r[0]: {
+            "updates_total": int(r[1] or 0),
+            "security_total": int(r[2] or 0),
+            "checked_at": r[3],
+        }
+        for r in rows
+        if r[0] in host_by_id
+    }
+
+    cve_map: dict[object, dict] = {}
+    for finding in collect_high_severity_findings(db, min_severity=7.0):
+        if finding.host_id not in host_by_id:
+            continue
+        item = cve_map.setdefault(
+            finding.host_id,
+            {
+                "critical_cves": 0,
+                "high_cves": 0,
+                "max_cve_severity": 0.0,
+                "cve_ids": set(),
+                "packages": set(),
+                "candidate_fix_packages": set(),
+            },
+        )
+        sev = float(finding.severity or 0.0)
+        if sev >= 9.0:
+            item["critical_cves"] += 1
+        else:
+            item["high_cves"] += 1
+        item["max_cve_severity"] = max(float(item["max_cve_severity"]), sev)
+        item["cve_ids"].add(str(finding.cve_id))
+        item["packages"].add(str(finding.package_name))
+        if finding.candidate_fixes is True:
+            item["candidate_fix_packages"].add(str(finding.package_name))
+
+    items = []
+    for host in hosts:
+        upd = update_map.get(host.id) or {"updates_total": 0, "security_total": 0, "checked_at": None}
+        cve = cve_map.get(host.id) or {
+            "critical_cves": 0,
+            "high_cves": 0,
+            "max_cve_severity": 0.0,
+            "cve_ids": set(),
+            "packages": set(),
+            "candidate_fix_packages": set(),
+        }
+        critical_cves = int(cve["critical_cves"])
+        high_cves = int(cve["high_cves"])
+        security_updates = int(upd["security_total"])
+        updates_total = int(upd["updates_total"])
+        if critical_cves <= 0 and high_cves <= 0 and security_updates <= 0:
+            continue
+
+        score = (
+            critical_cves * 10000
+            + high_cves * 1000
+            + float(cve["max_cve_severity"]) * 100
+            + security_updates * 10
+            + updates_total
+        )
+        reasons = []
+        if critical_cves:
+            reasons.append(f"{critical_cves} critical CVE{'s' if critical_cves != 1 else ''}")
+        if high_cves:
+            reasons.append(f"{high_cves} high CVE{'s' if high_cves != 1 else ''}")
+        if security_updates:
+            reasons.append(f"{security_updates} security update{'s' if security_updates != 1 else ''}")
+
+        items.append(
+            {
+                "agent_id": host.agent_id,
+                "hostname": host.hostname,
+                "online": _is_host_online(host, now=now),
+                "last_seen": host.last_seen.isoformat() if host.last_seen else None,
+                "critical_cves": critical_cves,
+                "high_cves": high_cves,
+                "max_cve_severity": float(cve["max_cve_severity"]),
+                "cve_count": len(cve["cve_ids"]),
+                "vulnerable_packages": len(cve["packages"]),
+                "candidate_fix_packages": len(cve["candidate_fix_packages"]),
+                "security_updates": security_updates,
+                "updates_total": updates_total,
+                "checked_at": upd["checked_at"].isoformat() if upd["checked_at"] else None,
+                "priority_score": round(score, 2),
+                "reason": ", ".join(reasons),
+            }
+        )
+
+    items.sort(
+        key=lambda item: (
+            -int(item["critical_cves"]),
+            -float(item["max_cve_severity"]),
+            -int(item["high_cves"]),
+            -int(item["security_updates"]),
+            -int(item["updates_total"]),
+            str(item["hostname"]),
+        )
+    )
+
+    return {
+        "ts": now.isoformat(),
+        "limit": limit,
+        "total": len(items),
+        "items": items[:limit],
     }
 
 

--- a/server/app/templates/fleet-phase3-overview.js
+++ b/server/app/templates/fleet-phase3-overview.js
@@ -314,6 +314,7 @@
     }
 
     ctx.loadPendingUpdatesReport();
+    loadUrgentUpdates(ctx);
   }
 
   let hostsTableItemsCache = [];
@@ -840,6 +841,68 @@
     } catch (e) {
       if (showToastOnManual) w.showToast(`Report refresh failed: ${e.message}`, 'error');
       w.setTableState(tbody, 7, 'error', `Report error: ${e.message}`);
+    }
+  }
+
+  async function loadUrgentUpdates(ctx) {
+    const tbody = document.getElementById('overview-urgent-updates');
+    if (!tbody) return;
+    w.setTableState(tbody, 7, 'loading', 'Loading…');
+
+    try {
+      const r = await fetch('/dashboard/urgent-updates?limit=10', { credentials: 'include' });
+      if (!r.ok) throw await buildHttpError(r, 'urgent updates failed');
+      const d = await r.json();
+      const items = Array.isArray(d?.items) ? d.items : [];
+      if (!items.length) return w.setTableState(tbody, 7, 'empty', 'No urgent update backlog found.');
+
+      tbody.innerHTML = '';
+      for (const it of items) {
+        const agentId = String(it.agent_id || '');
+        const hostName = String(it.hostname || agentId || '–');
+        const critical = Number(it.critical_cves || 0);
+        const high = Number(it.high_cves || 0);
+        const security = Number(it.security_updates || 0);
+        const severity = Number(it.max_cve_severity || 0);
+        const urgentClass = critical > 0 ? 'status-error' : (high > 0 || security > 0 ? 'status-warn' : 'status-muted');
+        const reason = String(it.reason || 'Updates pending');
+        const online = it.online ? '<span class="status-ok">online</span>' : '<span class="status-error">offline</span>';
+        const lastSeen = formatShortTimeSafe(ctx, it.last_seen);
+        const detail = severity > 0
+          ? `${reason}; max CVE severity ${severity.toFixed(1)}`
+          : reason;
+
+        const tr = document.createElement('tr');
+        tr.innerHTML = `
+          <td><a href="#" class="urgent-host" data-agent-id="${w.escapeHtml(agentId)}" data-hostname="${w.escapeHtml(hostName)}" style="font-weight:700;text-decoration:underline;">${w.escapeHtml(hostName)}</a><div style="color:var(--muted-2);font-size:0.85rem;">${w.escapeHtml(agentId)}</div></td>
+          <td class="${urgentClass}" style="white-space:normal;overflow-wrap:anywhere;">${w.escapeHtml(detail)}</td>
+          <td style="text-align:right;"><b>${critical}</b></td>
+          <td style="text-align:right;"><b>${high}</b></td>
+          <td style="text-align:right;"><b>${security}</b></td>
+          <td>${online}</td>
+          <td class="status-muted">${w.escapeHtml(lastSeen)}</td>
+        `;
+        tbody.appendChild(tr);
+      }
+
+      tbody.querySelectorAll('a.urgent-host').forEach((a) => {
+        a.addEventListener('click', (e) => {
+          e.preventDefault();
+          const aid = a.getAttribute('data-agent-id') || '';
+          const hostname = a.getAttribute('data-hostname') || aid;
+          if (!aid) return;
+          ctx.selectHost(aid, hostname);
+          ctx.showPackages();
+          const updatesOnlyEl = document.getElementById('packages-updates-only');
+          if (updatesOnlyEl) {
+            updatesOnlyEl.checked = true;
+            ctx.setPackagesUpdatesOnly(true);
+            ctx.loadPackages(aid);
+          }
+        });
+      });
+    } catch (e) {
+      w.setTableState(tbody, 7, 'error', `Urgent updates error: ${e.message || String(e)}`);
     }
   }
 

--- a/server/app/templates/index.html
+++ b/server/app/templates/index.html
@@ -269,6 +269,33 @@
             </div>
 
 
+            <div class="admin-card" style="margin-top:1rem;">
+              <div class="admin-card-title">10 hosts needing urgent updates</div>
+              <div class="admin-card-body">
+                <div style="overflow-x:auto;">
+                  <table class="process-table" style="min-width:820px;">
+                    <thead>
+                      <tr>
+                        <th>Host</th>
+                        <th>Urgency</th>
+                        <th style="text-align:right;">Critical CVEs</th>
+                        <th style="text-align:right;">High CVEs</th>
+                        <th style="text-align:right;">Security updates</th>
+                        <th>Online</th>
+                        <th>Last seen</th>
+                      </tr>
+                    </thead>
+                    <tbody id="overview-urgent-updates">
+                      <tr>
+                        <td colspan="7" style="text-align:center;" class="status-muted">Loading…</td>
+                      </tr>
+                    </tbody>
+                  </table>
+                </div>
+              </div>
+            </div>
+
+
             <div class="admin-card" id="notifications-card" style="margin-top:1rem;">
               <div class="admin-card-title" style="display:flex;align-items:center;justify-content:space-between;gap:1rem;flex-wrap:wrap;">
                 <span>Notification Center</span>

--- a/server/tests/test_cve_report_api.py
+++ b/server/tests/test_cve_report_api.py
@@ -119,3 +119,107 @@ def test_cve_high_severity_report_api(monkeypatch):
         assert "openssl" in r.text
         assert "Upgrade fixes" in r.text
         assert "https://ubuntu.com/security/CVE-2026-9998" in r.text
+
+
+def test_dashboard_urgent_updates_ranks_critical_cves_first(monkeypatch):
+    monkeypatch.setenv("DATABASE_URL", "sqlite+pysqlite:///:memory:")
+    monkeypatch.setenv("BOOTSTRAP_USERNAME", "admin")
+    monkeypatch.setenv("BOOTSTRAP_PASSWORD", "admin-password-123")
+    monkeypatch.setenv("UI_COOKIE_SECURE", "false")
+    monkeypatch.setenv("ALLOW_INSECURE_NO_AGENT_TOKEN", "true")
+    monkeypatch.setenv("AGENT_SHARED_TOKEN", "")
+    monkeypatch.setenv("DB_AUTO_CREATE_TABLES", "true")
+    monkeypatch.setenv("DB_REQUIRE_MIGRATIONS_UP_TO_DATE", "false")
+    monkeypatch.setenv("MFA_REQUIRE_FOR_PRIVILEGED", "false")
+
+    app_factory = importlib.import_module("app.app_factory")
+    app = app_factory.create_app()
+
+    from app.db import SessionLocal
+    from app.models import CVEDefinition, CVEPackage, Host, HostPackage, HostPackageUpdate
+    from fastapi.testclient import TestClient
+
+    with TestClient(app) as client:
+        r = client.post("/auth/login", json={"username": "admin", "password": "admin-password-123"})
+        assert r.status_code == 200, r.text
+
+        with SessionLocal() as db:
+            critical = Host(
+                agent_id="critical-1",
+                hostname="critical-1",
+                os_id="ubuntu",
+                os_version="Ubuntu 24.04 noble",
+                last_seen=datetime.now(timezone.utc),
+                labels={"env": "prod"},
+            )
+            backlog = Host(
+                agent_id="backlog-1",
+                hostname="backlog-1",
+                os_id="ubuntu",
+                os_version="Ubuntu 24.04 noble",
+                last_seen=datetime.now(timezone.utc),
+                labels={"env": "prod"},
+            )
+            db.add_all([critical, backlog])
+            db.flush()
+
+            db.add(
+                HostPackage(
+                    host_id=critical.id,
+                    name="openssl",
+                    arch="amd64",
+                    version="1.0.0",
+                    manager="apt",
+                    collected_at=datetime.now(timezone.utc),
+                )
+            )
+            db.add(
+                HostPackageUpdate(
+                    host_id=critical.id,
+                    name="openssl",
+                    installed_version="1.0.0",
+                    candidate_version="1.0.2",
+                    is_security=True,
+                    update_available=True,
+                    checked_at=datetime.now(timezone.utc),
+                )
+            )
+            db.add(CVEDefinition(cve_id="CVE-2026-1111", definition_data={"severity": 9.8}, severity="9.8"))
+            db.add(
+                CVEPackage(
+                    cve_id="CVE-2026-1111",
+                    package_name="openssl",
+                    release="noble",
+                    fixed_version="1.0.2",
+                    status="released",
+                    severity="9.8",
+                )
+            )
+
+            for idx in range(12):
+                name = f"pkg{idx}"
+                db.add(
+                    HostPackageUpdate(
+                        host_id=backlog.id,
+                        name=name,
+                        installed_version="1.0.0",
+                        candidate_version="1.0.1",
+                        is_security=True,
+                        update_available=True,
+                        checked_at=datetime.now(timezone.utc),
+                    )
+                )
+            db.commit()
+
+        r = client.get("/dashboard/urgent-updates?limit=10")
+        assert r.status_code == 200, r.text
+        data = r.json()
+        hostnames = [item["hostname"] for item in data["items"]]
+        critical_idx = hostnames.index("critical-1")
+        backlog_idx = hostnames.index("backlog-1")
+        assert critical_idx < backlog_idx
+        critical_item = data["items"][critical_idx]
+        backlog_item = data["items"][backlog_idx]
+        assert critical_item["critical_cves"] >= 1
+        assert critical_item["security_updates"] == 1
+        assert backlog_item["security_updates"] == 12


### PR DESCRIPTION
## Summary
- add a Dashboard endpoint that ranks urgent update targets by critical/high CVE exposure and security-update backlog
- show the top 10 urgent hosts on the Dashboard with clickable host rows
- add coverage for critical-CVE-first ranking

## Tests
- .venv/bin/pytest server/tests/test_cve_report_api.py -q
- .venv/bin/pytest server/tests/test_overview_reliability_smoke.py -q
- npm run test:frontend