### PR TITLE
Make dashboard auto refresh silent

### DIFF
--- a/server/app/templates/fleet-phase3-overview.js
+++ b/server/app/templates/fleet-phase3-overview.js
@@ -65,7 +65,8 @@
     return raw || fallback;
   }
 
-  async function loadFleetOverview(ctx, forceLive) {
+  async function loadFleetOverview(ctx, forceLive, backgroundRefresh) {
+    const isBackgroundRefresh = !!backgroundRefresh;
     const onlineEl = document.getElementById('kpi-online');
     const onlineDetailsEl = document.getElementById('kpi-online-details');
     const secEl = document.getElementById('kpi-sec');
@@ -192,7 +193,7 @@
       }
 
       if (nextCronEl) {
-        nextCronEl.innerHTML = '<div class="loading">Loading cronjobs…</div>';
+        if (!isBackgroundRefresh) nextCronEl.innerHTML = '<div class="loading">Loading cronjobs…</div>';
         try {
           const rc = await fetch('/cronjobs', { credentials: 'include' });
           if (!rc.ok) throw await buildHttpError(rc, 'cronjobs failed');
@@ -223,7 +224,7 @@
       }
 
       if (attentionEl) {
-        attentionEl.innerHTML = '<div class="loading">Loading attention list…</div>';
+        if (!isBackgroundRefresh) attentionEl.innerHTML = '<div class="loading">Loading attention list…</div>';
         try {
           const r2 = await fetch(`/dashboard/attention?limit=200&include_live=true&force_live=${forceLive ? 'true' : 'false'}`, { credentials: 'include' });
           if (!r2.ok) throw await buildHttpError(r2, 'attention failed');
@@ -310,11 +311,11 @@
         }
       } catch (_) { }
 
-      if (attentionEl) attentionEl.textContent = `Overview error: ${e.message}`;
+      if (attentionEl && !isBackgroundRefresh) attentionEl.textContent = `Overview error: ${e.message}`;
     }
 
-    ctx.loadPendingUpdatesReport();
-    loadUrgentUpdates(ctx);
+    ctx.loadPendingUpdatesReport(false, isBackgroundRefresh);
+    loadUrgentUpdates(ctx, isBackgroundRefresh);
   }
 
   let hostsTableItemsCache = [];
@@ -796,16 +797,17 @@
     }
   }
 
-  async function loadPendingUpdatesReport(ctx, showToastOnManual) {
+  async function loadPendingUpdatesReport(ctx, showToastOnManual, backgroundRefresh) {
     const tbody = document.getElementById('overview-updates-report');
     if (!tbody) return;
+    const isBackgroundRefresh = !!backgroundRefresh;
 
     const sortSel = document.getElementById('report-sort');
     const orderSel = document.getElementById('report-order');
     const sort = sortSel?.value || 'security_updates';
     const order = orderSel?.value || 'desc';
     w.updateReportSortIndicators(sort, order);
-    w.setTableState(tbody, 7, 'loading', 'Loading…');
+    if (!isBackgroundRefresh) w.setTableState(tbody, 7, 'loading', 'Loading…');
 
     try {
       const url = `/reports/hosts-updates?only_pending=true&online_only=false&sort=${encodeURIComponent(sort)}&order=${encodeURIComponent(order)}&limit=100`;
@@ -844,10 +846,11 @@
     }
   }
 
-  async function loadUrgentUpdates(ctx) {
+  async function loadUrgentUpdates(ctx, backgroundRefresh) {
     const tbody = document.getElementById('overview-urgent-updates');
     if (!tbody) return;
-    w.setTableState(tbody, 7, 'loading', 'Loading…');
+    const isBackgroundRefresh = !!backgroundRefresh;
+    if (!isBackgroundRefresh) w.setTableState(tbody, 7, 'loading', 'Loading…');
 
     try {
       const r = await fetch('/dashboard/urgent-updates?limit=10', { credentials: 'include' });

--- a/server/app/templates/index.html
+++ b/server/app/templates/index.html
@@ -3351,7 +3351,7 @@
         showPackages,
         loadPackages,
         setPackagesUpdatesOnly: (v) => { packagesUpdatesOnly = !!v; },
-        loadPendingUpdatesReport: (showToastOnManual = false) => loadPendingUpdatesReport(showToastOnManual),
+        loadPendingUpdatesReport: (showToastOnManual = false, backgroundRefresh = false) => loadPendingUpdatesReport(showToastOnManual, backgroundRefresh),
         clearCurrentHostSelection,
         stopMetricsPolling: () => stopMetricsPolling(metricsLifecycleState),
         loadHostsTable,
@@ -3360,7 +3360,7 @@
         loadSshKeyRequests,
         maybeLoadSshKeyAdminQueue,
         loadAdminSshKeys,
-        loadFleetOverview: (forceLive = false) => loadFleetOverview(forceLive),
+        loadFleetOverview: (forceLive = false, backgroundRefresh = false) => loadFleetOverview(forceLive, backgroundRefresh),
         loadFailedRuns,
         loadHosts,
         getLastRenderedAgentIds: () => lastRenderedAgentIds,
@@ -3384,10 +3384,10 @@
       };
     }
 
-    async function loadFleetOverview(forceLive = false) {
+    async function loadFleetOverview(forceLive = false, backgroundRefresh = false) {
       const mod = window.phase3Overview;
       if (mod && typeof mod.loadFleetOverview === 'function') {
-        return mod.loadFleetOverview(getOverviewCtx(), forceLive);
+        return mod.loadFleetOverview(getOverviewCtx(), forceLive, backgroundRefresh);
       }
     }
 
@@ -3771,10 +3771,10 @@
       bindSortableHeader('hosts-th-last', () => setSort('last_seen'));
     }
 
-    async function loadPendingUpdatesReport(showToastOnManual = false) {
+    async function loadPendingUpdatesReport(showToastOnManual = false, backgroundRefresh = false) {
       const mod = window.phase3Overview;
       if (mod && typeof mod.loadPendingUpdatesReport === 'function') {
-        return mod.loadPendingUpdatesReport(getOverviewCtx(), showToastOnManual);
+        return mod.loadPendingUpdatesReport(getOverviewCtx(), showToastOnManual, backgroundRefresh);
       }
     }
 
@@ -5581,7 +5581,7 @@
     void loadFleetOverview();
     void refreshApprovalsIndicator();
     startHostRefresh();
-    setInterval(() => { void loadFleetOverview(); }, 15000);
+    setInterval(() => { void loadFleetOverview(false, true); }, 15000);
     setInterval(() => { void refreshApprovalsIndicator(); }, 60000);
   </script>
 </body>

--- a/server/tests/test_overview_reliability_smoke.py
+++ b/server/tests/test_overview_reliability_smoke.py
@@ -102,3 +102,16 @@ def test_mfa_gate_403_is_suppressed_in_overview_js():
     assert "if (r.status === 403)" in js
     assert "Expected transient state during MFA gating" in js
     assert "if (r.status === 403) return; // MFA transient" in js
+
+
+def test_dashboard_auto_refresh_is_silent():
+    from pathlib import Path
+
+    root = Path(__file__).resolve().parents[2]
+    html = (root / "server" / "app" / "templates" / "index.html").read_text(encoding="utf-8")
+    js = (root / "server" / "app" / "templates" / "fleet-phase3-overview.js").read_text(encoding="utf-8")
+
+    assert "loadFleetOverview(false, true)" in html
+    assert "const isBackgroundRefresh = !!backgroundRefresh;" in js
+    assert "if (!isBackgroundRefresh) attentionEl.innerHTML" in js
+    assert "if (!isBackgroundRefresh) w.setTableState(tbody, 7, 'loading', 'Loading…');" in js


### PR DESCRIPTION
## Summary
- make the 15-second Dashboard auto-refresh run in background mode
- avoid replacing populated Dashboard sections/tables with Loading states during automatic refresh
- keep manual Refresh button behavior unchanged

## Tests
- .venv/bin/pytest server/tests/test_overview_reliability_smoke.py -q
- npm run test:frontend