### PR TITLE
Update README with Docker installation instructions for RedHat

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,25 @@ Compose, Git, Python, OpenSSL, Ansible, and Go.
 RedHat: install manually needed packages
 
 ```bash
+# Remove any conflicting packages
+
+sudo dnf remove -y docker \
+  docker-client \
+  docker-client-latest \
+  docker-common \
+  docker-latest \
+  docker-latest-logrotate \
+  docker-logrotate \
+  docker-engine \
+  podman \
+  runc
+
+# Install required packages
+sudo dnf install -y dnf-plugins-core
+
+# Add Docker's official repository
+sudo dnf config-manager --add-repo \
+  https://download.docker.com/linux/rhel/docker-ce.repo
 sudo dnf install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
 ```
 


### PR DESCRIPTION
Added instructions for removing conflicting Docker packages and installing required packages on RedHat.