### PR TITLE
Harden Ansible and terminal access

### DIFF
--- a/agent/internal/terminal.go
+++ b/agent/internal/terminal.go
@@ -4,6 +4,7 @@ import (
 	"log"
 	"net"
 	"net/http"
+	"net/url"
 	"os"
 	"os/exec"
 	"strings"
@@ -24,7 +25,19 @@ func getenv(k, d string) string {
 var upgrader = websocket.Upgrader{
 	// NOTE: Origin checks are not a security boundary on their own for non-browser clients.
 	// We also require an explicit token.
-	CheckOrigin: func(r *http.Request) bool { return true },
+	CheckOrigin: sameHostOrigin,
+}
+
+func sameHostOrigin(r *http.Request) bool {
+	origin := strings.TrimSpace(r.Header.Get("Origin"))
+	if origin == "" {
+		return true
+	}
+	u, err := url.Parse(origin)
+	if err != nil || u.Host == "" {
+		return false
+	}
+	return strings.EqualFold(u.Host, r.Host)
 }
 
 func commandPath(candidates ...string) string {

--- a/agent/internal/terminal_test.go
+++ b/agent/internal/terminal_test.go
@@ -1,6 +1,7 @@
 package internal
 
 import (
+	"net/http"
 	"os"
 	"strings"
 	"testing"
@@ -45,5 +46,17 @@ func TestPrefersSSHConsoleBackendHonorsExplicitBackend(t *testing.T) {
 func TestRunTerminalSSHLoginFromArgsIgnoresNormalAgentStart(t *testing.T) {
 	if RunTerminalSSHLoginFromArgs([]string{os.Args[0]}) {
 		t.Fatal("RunTerminalSSHLoginFromArgs() = true for normal agent args")
+	}
+}
+
+func TestSameHostOrigin(t *testing.T) {
+	if !sameHostOrigin(&http.Request{Host: "agent.local:18080", Header: http.Header{}}) {
+		t.Fatal("sameHostOrigin without Origin = false, want true")
+	}
+	if !sameHostOrigin(&http.Request{Host: "agent.local:18080", Header: http.Header{"Origin": []string{"http://agent.local:18080"}}}) {
+		t.Fatal("sameHostOrigin matching Origin = false, want true")
+	}
+	if sameHostOrigin(&http.Request{Host: "agent.local:18080", Header: http.Header{"Origin": []string{"http://evil.local"}}}) {
+		t.Fatal("sameHostOrigin cross-site Origin = true, want false")
 	}
 }

--- a/deploy/docker/docker-compose.yml
+++ b/deploy/docker/docker-compose.yml
@@ -48,9 +48,8 @@ services:
 
       # Agent auth tokens (set in .env; do NOT commit real values)
       AGENT_SHARED_TOKEN: ${AGENT_SHARED_TOKEN:-}
-      # Local compose defaults use placeholder/dev settings. Set false in production
-      # after replacing placeholders and enabling HTTPS/migration guardrails.
-      ALLOW_INSECURE_NO_AGENT_TOKEN: ${ALLOW_INSECURE_NO_AGENT_TOKEN:-true}
+      # Keep false unless intentionally running loopback-only tests without an agent token.
+      ALLOW_INSECURE_NO_AGENT_TOKEN: ${ALLOW_INSECURE_NO_AGENT_TOKEN:-false}
       # High-risk feature: only enable if agent has FLEET_TERMINAL_TOKEN set too
       AGENT_TERMINAL_TOKEN: ${AGENT_TERMINAL_TOKEN:-}
       # For production behind HTTPS, set AGENT_TERMINAL_SCHEME=wss

--- a/deploy/docker/env.example
+++ b/deploy/docker/env.example
@@ -39,9 +39,8 @@ ADMIN_ENABLE_MIGRATIONS_ENDPOINT=false
 
 # Agent auth tokens (shared secret MVP)
 AGENT_SHARED_TOKEN=change-me-agent-token
-# Local Docker Compose default. Set false for production after replacing placeholder secrets
-# and enabling HTTPS/migration guardrails.
-ALLOW_INSECURE_NO_AGENT_TOKEN=true
+# Keep false unless intentionally running loopback-only tests without an agent token.
+ALLOW_INSECURE_NO_AGENT_TOKEN=false
 # Terminal proxy token (server-side). Must match the agent-side token (FLEET_TERMINAL_TOKEN).
 AGENT_TERMINAL_TOKEN=change-me-terminal-token
 # Use wss in production when running behind HTTPS reverse proxy.

--- a/install.sh
+++ b/install.sh
@@ -328,7 +328,7 @@ main() {
   set_env_value "$docker_env" "AGENT_SHARED_TOKEN" "$agent_token"
   set_env_value "$docker_env" "MFA_ENCRYPTION_KEY" "$mfa_key"
   set_env_value "$docker_env" "UI_COOKIE_SECURE" "false"
-  set_env_value "$docker_env" "ALLOW_INSECURE_NO_AGENT_TOKEN" "true"
+  set_env_value "$docker_env" "ALLOW_INSECURE_NO_AGENT_TOKEN" "false"
   set_env_value "$docker_env" "DB_AUTO_CREATE_TABLES" "true"
   set_env_value "$docker_env" "DB_REQUIRE_MIGRATIONS_UP_TO_DATE" "true"
   set_env_value "$docker_env" "AGENT_TERMINAL_TOKEN" "$terminal_token"

--- a/server/app/routers/ansible.py
+++ b/server/app/routers/ansible.py
@@ -1,14 +1,11 @@
 from __future__ import annotations
 
 import asyncio
-import json
-import re
-import subprocess
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, status
 from fastapi.responses import FileResponse, JSONResponse
 from pydantic import BaseModel
 from sqlalchemy import func, select
@@ -16,12 +13,70 @@ from sqlalchemy.orm import Session
 
 from ..db import get_db
 from ..deps import require_ui_user
-from ..models import AnsibleRun, AppUser
+from ..models import AnsibleRun, AppUser, Host
 from ..services.ansible import list_playbooks, redact_extra_vars, run_playbook
 from ..services.ansible_runs import create_run, get_run_by_key
 from ..services.db_utils import transaction
+from ..services.hosts import resolve_host_target
+from ..services.rbac import permissions_for
+from ..services.user_scopes import filter_agent_ids_for_user
 
 router = APIRouter(prefix="/ansible", tags=["ansible"])
+
+
+def _require_ansible_access(user: AppUser) -> None:
+    if not permissions_for(user).get("can_run_ansible"):
+        raise HTTPException(status.HTTP_403_FORBIDDEN, "Insufficient permissions to run Ansible")
+
+
+def _is_admin(user: AppUser) -> bool:
+    return (permissions_for(user).get("role") or "").lower() == "admin"
+
+
+def _normalize_agent_ids(agent_ids: list[str] | None) -> list[str]:
+    seen: set[str] = set()
+    out: list[str] = []
+    for raw in agent_ids or []:
+        aid = str(raw or "").strip()
+        if aid and aid not in seen:
+            seen.add(aid)
+            out.append(aid)
+    return out
+
+
+def _visible_ansible_targets(db: Session, user: AppUser, agent_ids: list[str]) -> list[str]:
+    targets = _normalize_agent_ids(agent_ids)
+    if not targets:
+        raise HTTPException(400, "agent_ids is required")
+
+    known = set(db.execute(select(Host.agent_id).where(Host.agent_id.in_(targets))).scalars().all())
+    missing = [aid for aid in targets if aid not in known]
+    if missing:
+        raise HTTPException(404, "Unknown Ansible target")
+
+    if _is_admin(user):
+        return targets
+
+    visible = set(filter_agent_ids_for_user(db, user, targets))
+    if visible != set(targets):
+        raise HTTPException(404, "Unknown Ansible target")
+    return targets
+
+
+def _can_view_ansible_run(db: Session, user: AppUser, run: AnsibleRun) -> bool:
+    if _is_admin(user):
+        return True
+    targets = _normalize_agent_ids(run.targets or [])
+    if not targets:
+        return False
+    visible = set(filter_agent_ids_for_user(db, user, targets))
+    return visible == set(targets)
+
+
+def _require_can_view_ansible_run(db: Session, user: AppUser, run: AnsibleRun) -> None:
+    _require_ansible_access(user)
+    if not _can_view_ansible_run(db, user, run):
+        raise HTTPException(404, "Ansible run not found")
 
 
 @router.get("/runs")
@@ -34,6 +89,8 @@ def list_ansible_runs(
     user: AppUser = Depends(require_ui_user),
     db: Session = Depends(get_db),
 ):
+    _require_ansible_access(user)
+
     if limit < 1:
         limit = 1
     if limit > 200:
@@ -53,8 +110,14 @@ def list_ansible_runs(
     if created_by:
         q = q.where(AnsibleRun.created_by == created_by)
 
-    total = db.execute(select(func.count()).select_from(q.subquery())).scalar_one()
-    rows = db.execute(q.limit(limit).offset(offset)).scalars().all()
+    if _is_admin(user):
+        total = db.execute(select(func.count()).select_from(q.subquery())).scalar_one()
+        rows = db.execute(q.limit(limit).offset(offset)).scalars().all()
+    else:
+        all_rows = db.execute(q).scalars().all()
+        visible_rows = [r for r in all_rows if _can_view_ansible_run(db, user, r)]
+        total = len(visible_rows)
+        rows = visible_rows[offset: offset + limit]
 
     items = [
         {
@@ -79,6 +142,7 @@ def list_ansible_runs(
 @router.get("/runs/{run_id}")
 def get_ansible_run(run_id: str, user: AppUser = Depends(require_ui_user), db: Session = Depends(get_db)):
     r = get_run_by_key(db, run_id)
+    _require_can_view_ansible_run(db, user, r)
     return {
         "run_id": r.run_key,
         "playbook": r.playbook,
@@ -102,6 +166,7 @@ def get_ansible_run(run_id: str, user: AppUser = Depends(require_ui_user), db: S
 def get_ansible_run_log(run_id: str, user: AppUser = Depends(require_ui_user), db: Session = Depends(get_db)):
     """Download the stored log artifact for a run (if present)."""
     r = get_run_by_key(db, run_id)
+    _require_can_view_ansible_run(db, user, r)
     if not r.log_name:
         raise HTTPException(404, "log not available")
 
@@ -119,6 +184,7 @@ class AnsibleRunRequest(BaseModel):
 
 @router.get("/playbooks")
 def ansible_playbooks(user: AppUser = Depends(require_ui_user)):
+    _require_ansible_access(user)
     return list_playbooks()
 
 
@@ -128,13 +194,16 @@ async def ansible_run(
     user: AppUser = Depends(require_ui_user),
     db: Session = Depends(get_db),
 ):
+    _require_ansible_access(user)
+    targets = _visible_ansible_targets(db, user, payload.agent_ids)
+
     # Create DB record first (so UI can show it immediately)
     redacted = redact_extra_vars(payload.playbook, payload.extra_vars)
     with transaction(db):
         run = create_run(
             db=db,
             playbook=payload.playbook,
-            targets=payload.agent_ids,
+            targets=targets,
             extra_vars_redacted=redacted,
             created_by=getattr(user, "username", None),
         )
@@ -142,20 +211,17 @@ async def ansible_run(
 
     try:
         # Resolve selected agent ids to connection targets (prefer IP, then FQDN, then hostname).
-        from ..models import Host
-        from ..services.hosts import resolve_host_target
-
-        hosts = db.execute(select(Host).where(Host.agent_id.in_(payload.agent_ids))).scalars().all()
+        hosts = db.execute(select(Host).where(Host.agent_id.in_(targets))).scalars().all()
         by_id = {h.agent_id: h for h in hosts}
         inventory_hosts: list[str] = []
-        for aid in payload.agent_ids:
+        for aid in targets:
             h = by_id.get(aid)
-            inventory_hosts.append(resolve_host_target(h) if h is not None else aid)
+            inventory_hosts.append(resolve_host_target(h))
 
         result = await asyncio.to_thread(
             run_playbook,
             payload.playbook,
-            payload.agent_ids,
+            targets,
             payload.extra_vars,
             inventory_hosts=inventory_hosts,
         )
@@ -194,6 +260,9 @@ async def ansible_run(
 
 @router.get("/logs")
 def ansible_log_list(limit: int = 50, user: AppUser = Depends(require_ui_user)):
+    _require_ansible_access(user)
+    if not _is_admin(user):
+        raise HTTPException(403, "Admin privileges required")
     from ..services.ansible import list_logs
 
     return list_logs(limit=limit)
@@ -201,6 +270,9 @@ def ansible_log_list(limit: int = 50, user: AppUser = Depends(require_ui_user)):
 
 @router.get("/logs/{log_name}")
 def ansible_log_file(log_name: str, user: AppUser = Depends(require_ui_user)):
+    _require_ansible_access(user)
+    if not _is_admin(user):
+        raise HTTPException(403, "Admin privileges required")
     from ..services.ansible import get_log_file
 
     path = get_log_file(log_name)

--- a/server/app/routers/terminal_ws.py
+++ b/server/app/routers/terminal_ws.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 from contextlib import suppress
 from datetime import datetime, timezone
+from urllib.parse import urlparse
 
 from fastapi import APIRouter, WebSocket
 from sqlalchemy import select
@@ -20,8 +21,38 @@ logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/ws", tags=["terminal"])
 
 
+def _split_host(value: str | None) -> str:
+    return str(value or "").split(",", 1)[0].strip().lower()
+
+
+def _websocket_origin_allowed(headers) -> bool:
+    origin = _split_host(headers.get("origin"))
+    if not origin:
+        # Non-browser clients normally omit Origin. Browser clients send it.
+        return True
+
+    try:
+        parsed_origin = urlparse(origin)
+    except Exception:
+        return False
+    if parsed_origin.scheme not in {"http", "https"} or not parsed_origin.netloc:
+        return False
+
+    allowed_hosts = {
+        _split_host(headers.get("host")),
+        _split_host(headers.get("x-forwarded-host")),
+    }
+    allowed_hosts.discard("")
+
+    return parsed_origin.netloc.lower() in allowed_hosts
+
+
 @router.websocket("/terminal/{agent_id}")
 async def ws_terminal(ws: WebSocket, agent_id: str) -> None:
+    if not _websocket_origin_allowed(ws.headers):
+        await ws.close(code=1008, reason="Invalid Origin")
+        return
+
     await ws.accept()
 
     db = SessionLocal()

--- a/server/tests/test_jobs_flow.py
+++ b/server/tests/test_jobs_flow.py
@@ -232,6 +232,114 @@ def test_jobs_readonly_cannot_run_and_cannot_read_out_of_scope(monkeypatch):
         assert hidden_stdout.status_code == 404, hidden_stdout.text
 
 
+def test_ansible_requires_operator_and_owned_targets(monkeypatch):
+    monkeypatch.setenv("DATABASE_URL", "sqlite+pysqlite:///:memory:")
+    monkeypatch.setenv("BOOTSTRAP_USERNAME", "admin")
+    monkeypatch.setenv("BOOTSTRAP_PASSWORD", "admin-password-123")
+    monkeypatch.setenv("UI_COOKIE_SECURE", "false")
+    monkeypatch.setenv("ALLOW_INSECURE_NO_AGENT_TOKEN", "true")
+    monkeypatch.setenv("AGENT_SHARED_TOKEN", "")
+    monkeypatch.setenv("DB_AUTO_CREATE_TABLES", "true")
+    monkeypatch.setenv("DB_REQUIRE_MIGRATIONS_UP_TO_DATE", "false")
+    monkeypatch.setenv("MFA_REQUIRE_FOR_PRIVILEGED", "false")
+
+    app_factory = importlib.import_module("app.app_factory")
+    app = app_factory.create_app()
+
+    def fake_run_playbook(playbook, agent_ids, extra_vars, *args, **kwargs):
+        return {"ok": True, "rc": 0, "stdout": "ok", "stderr": "", "log_name": None, "log_path": None}
+
+    ansible_mod = importlib.import_module("app.services.ansible")
+    monkeypatch.setattr(ansible_mod, "run_playbook", fake_run_playbook)
+    ansible_router = importlib.import_module("app.routers.ansible")
+    monkeypatch.setattr(ansible_router, "run_playbook", fake_run_playbook)
+
+    from app.db import SessionLocal
+    from app.models import AppUser
+    from fastapi.testclient import TestClient
+
+    with TestClient(app) as admin_client:
+        for aid, owner in (("srv-owned", "ansible-op"), ("srv-other", "alice")):
+            rr = admin_client.post(
+                "/agent/register",
+                json={
+                    "agent_id": aid,
+                    "hostname": aid,
+                    "fqdn": None,
+                    "os_id": "ubuntu",
+                    "os_version": "24.04",
+                    "kernel": "test",
+                    "labels": {"owner": owner},
+                },
+            )
+            assert rr.status_code == 200, rr.text
+
+        with SessionLocal() as db:
+            from app.routers.auth import pwd_context
+            from app.services.ansible_runs import create_run
+
+            op = AppUser(
+                username="ansible-op",
+                password_hash=pwd_context.hash("user-pass-123"),
+                role="operator",
+                is_active=True,
+            )
+            viewer = AppUser(
+                username="ansible-viewer",
+                password_hash=pwd_context.hash("user-pass-123"),
+                role="readonly",
+                is_active=True,
+            )
+            db.add(op)
+            db.add(viewer)
+            hidden_run = create_run(
+                db=db,
+                playbook="noop.yml",
+                targets=["srv-other"],
+                extra_vars_redacted={},
+                created_by="admin",
+            )
+            hidden_run.status = "success"
+            db.commit()
+            hidden_run_id = hidden_run.run_key
+
+    with TestClient(app) as op_client:
+        lr2 = op_client.post("/auth/login", json={"username": "ansible-op", "password": "user-pass-123"})
+        assert lr2.status_code == 200, lr2.text
+        op_csrf = op_client.cookies.get("fleet_csrf")
+        op_headers = {"X-CSRF-Token": op_csrf} if op_csrf else {}
+
+        allowed = op_client.post(
+            "/ansible/run",
+            json={"playbook": "noop.yml", "agent_ids": ["srv-owned"]},
+            headers=op_headers,
+        )
+        assert allowed.status_code == 200, allowed.text
+
+        denied_target = op_client.post(
+            "/ansible/run",
+            json={"playbook": "noop.yml", "agent_ids": ["srv-other"]},
+            headers=op_headers,
+        )
+        assert denied_target.status_code == 404, denied_target.text
+
+        hidden_detail = op_client.get(f"/ansible/runs/{hidden_run_id}")
+        assert hidden_detail.status_code == 404, hidden_detail.text
+
+    with TestClient(app) as viewer_client:
+        lr3 = viewer_client.post("/auth/login", json={"username": "ansible-viewer", "password": "user-pass-123"})
+        assert lr3.status_code == 200, lr3.text
+        viewer_csrf = viewer_client.cookies.get("fleet_csrf")
+        viewer_headers = {"X-CSRF-Token": viewer_csrf} if viewer_csrf else {}
+
+        denied_readonly = viewer_client.post(
+            "/ansible/run",
+            json={"playbook": "noop.yml", "agent_ids": ["srv-owned"]},
+            headers=viewer_headers,
+        )
+        assert denied_readonly.status_code == 403, denied_readonly.text
+
+
 def test_pkg_upgrade_success_invalidates_cve_cache_and_queues_inventory(monkeypatch):
     monkeypatch.setenv("DATABASE_URL", "sqlite+pysqlite:///:memory:")
     monkeypatch.setenv("BOOTSTRAP_USERNAME", "admin")

--- a/server/tests/test_startup_guardrails.py
+++ b/server/tests/test_startup_guardrails.py
@@ -22,8 +22,9 @@ def test_non_local_when_insecure_override_is_disabled(monkeypatch):
     assert app_factory._is_non_local_deployment() is True
 
 
-def test_docker_compose_defaults_opt_into_local_dev_mode():
+def test_docker_compose_defaults_require_agent_token():
     root = Path(__file__).resolve().parents[2]
     for rel_path in ("deploy/docker/docker-compose.yml", "deploy/docker/env.example"):
         content = (root / rel_path).read_text(encoding="utf-8")
         assert "ALLOW_INSECURE_NO_AGENT_TOKEN" in content
+        assert "ALLOW_INSECURE_NO_AGENT_TOKEN:-false" in content or "ALLOW_INSECURE_NO_AGENT_TOKEN=false" in content

--- a/server/tests/test_terminal_pipe_transport.py
+++ b/server/tests/test_terminal_pipe_transport.py
@@ -103,3 +103,11 @@ def test_raw_pipe_closes_agent_when_browser_disconnects(monkeypatch):
     asyncio.run(terminal_pipe.raw_pipe(client_ws, "ws://agent/terminal/ws"))
 
     assert agent_ws.exited is True
+
+
+def test_terminal_websocket_origin_must_match_host():
+    from app.routers.terminal_ws import _websocket_origin_allowed
+
+    assert _websocket_origin_allowed({"host": "fleet.example.test", "origin": "https://fleet.example.test"})
+    assert _websocket_origin_allowed({"host": "fleet.example.test"})
+    assert not _websocket_origin_allowed({"host": "fleet.example.test", "origin": "https://evil.example.test"})


### PR DESCRIPTION
## Summary
- restrict Ansible APIs to users with Ansible permission and enforce registered/visible host targets
- hide Ansible run details/logs from users outside target scope and reserve raw log browsing for admins
- add same-host Origin checks for browser terminal WebSockets on both server and agent
- make Docker/install defaults require the generated agent shared token instead of tokenless agent mode

## Tests
- .venv/bin/pytest server/tests/test_jobs_flow.py server/tests/test_terminal_pipe_transport.py server/tests/test_startup_guardrails.py -q
- .venv/bin/pytest server/tests -q
- go test ./... (agent)