### PR TITLE
Show app version in sidebar

### DIFF
--- a/server/app/routers/ui.py
+++ b/server/app/routers/ui.py
@@ -11,6 +11,7 @@ from sqlalchemy.orm import Session
 from ..db import get_db
 from ..deps import get_current_user_from_request, require_ui_user
 from ..models import AppUser
+from ..version import APP_VERSION
 
 router = APIRouter(tags=["ui"])
 
@@ -47,6 +48,7 @@ def _read_template(name: str) -> str:
 def _render_template_with_nonce(name: str, request: Request) -> str:
     html = _read_template(name)
     html = html.replace("__ASSET_VERSION__", ASSET_VERSION)
+    html = html.replace("__APP_VERSION__", APP_VERSION)
     nonce = getattr(getattr(request, "state", None), "csp_nonce", None)
     if nonce:
         return html.replace("__CSP_NONCE__", str(nonce))

--- a/server/app/templates/fleet-ui-v2.css
+++ b/server/app/templates/fleet-ui-v2.css
@@ -104,12 +104,15 @@ body {
   position: sticky;
   top: 58px;
   align-self: start;
+  display: flex;
+  flex-direction: column;
   min-height: calc(100vh - 58px);
   background: var(--app-sidebar);
   border-right: 1px solid var(--app-sidebar-border);
 }
 
 #fleet-actions {
+  flex: 1 1 auto;
   margin: 0 !important;
   padding: 1.25rem 1.5rem !important;
   border-radius: 0;
@@ -160,6 +163,16 @@ body {
 #fleet-actions .btn:disabled {
   opacity: .45;
   cursor: not-allowed;
+}
+
+.fleet-app-version {
+  margin-top: auto;
+  padding: 0.85rem 1.5rem 1.05rem;
+  border-top: 1px solid color-mix(in srgb, var(--app-sidebar-border) 78%, transparent);
+  color: var(--app-sidebar-muted);
+  font-size: 0.78rem;
+  line-height: 1.2;
+  white-space: nowrap;
 }
 
 .container:has(#server-info-tab.active) #nav-overview,
@@ -582,6 +595,11 @@ body {
 #fleet-actions {
   padding: 1rem 0.75rem !important;
   gap: 0 !important;
+}
+
+.fleet-app-version {
+  padding: 0.75rem;
+  font-size: 0.75rem;
 }
 
 #fleet-actions .fleet-nav-section {
@@ -1071,6 +1089,10 @@ a,
 
   #fleet-actions {
     padding: 0.75rem !important;
+  }
+
+  .fleet-app-version {
+    display: none;
   }
 
   .fleet-main-shell {

--- a/server/app/templates/index.html
+++ b/server/app/templates/index.html
@@ -82,6 +82,7 @@
         <button class="btn" id="nav-cronjobs" type="button">Automation</button>
         <button class="btn" id="nav-reports" type="button">Reports</button>
       </div>
+      <div class="fleet-app-version">Version: __APP_VERSION__</div>
       </aside>
 
       <div class="fleet-main-shell">

--- a/server/app/version.py
+++ b/server/app/version.py
@@ -1,0 +1,1 @@
+APP_VERSION = "0.0.2-alpha"

--- a/server/tests/test_ui_version_footer.py
+++ b/server/tests/test_ui_version_footer.py
@@ -1,0 +1,13 @@
+from types import SimpleNamespace
+
+
+def test_sidebar_version_footer_is_rendered():
+    from app.routers import ui
+    from app.version import APP_VERSION
+
+    request = SimpleNamespace(state=SimpleNamespace(csp_nonce=None))
+    html = ui._render_template_with_nonce("index.html", request)
+
+    assert "__APP_VERSION__" not in html
+    assert 'class="fleet-app-version"' in html
+    assert f"Version: {APP_VERSION}" in html


### PR DESCRIPTION
## Summary
- add a server-side `APP_VERSION` constant set to `0.0.2-alpha`
- render `Version: 0.0.2-alpha` at the bottom of the left sidebar
- add a regression test that verifies the version placeholder is replaced in rendered UI HTML

## Tests
- `.venv/bin/pytest server/tests/test_ui_version_footer.py server/tests/test_overview_reliability_smoke.py server/tests/test_phase3_host_filters_frontend_smoke.py -q`
- `npm run test:frontend`
