### PR TITLE
Add disk cleanup and agent health

### DIFF
--- a/agent/cmd/fleet-agent/main.go
+++ b/agent/cmd/fleet-agent/main.go
@@ -10,6 +10,7 @@ import (
 	"log"
 	"net"
 	"net/http"
+	"net/url"
 	"os"
 	"os/exec"
 	"runtime"
@@ -18,6 +19,8 @@ import (
 	"sync"
 	"time"
 )
+
+const AgentVersion = "0.0.3-alpha"
 
 type Config struct {
 	ServerURL  string
@@ -30,14 +33,15 @@ type Config struct {
 }
 
 type RegisterPayload struct {
-	AgentID   string            `json:"agent_id"`
-	Hostname  string            `json:"hostname"`
-	FQDN      string            `json:"fqdn,omitempty"`
-	IPs       []string          `json:"ip_addresses,omitempty"`
-	OSID      string            `json:"os_id,omitempty"`
-	OSVersion string            `json:"os_version,omitempty"`
-	Kernel    string            `json:"kernel,omitempty"`
-	Labels    map[string]string `json:"labels"`
+	AgentID      string            `json:"agent_id"`
+	Hostname     string            `json:"hostname"`
+	FQDN         string            `json:"fqdn,omitempty"`
+	IPs          []string          `json:"ip_addresses,omitempty"`
+	OSID         string            `json:"os_id,omitempty"`
+	OSVersion    string            `json:"os_version,omitempty"`
+	Kernel       string            `json:"kernel,omitempty"`
+	AgentVersion string            `json:"agent_version,omitempty"`
+	Labels       map[string]string `json:"labels"`
 }
 
 type InventoryPayload struct {
@@ -71,18 +75,20 @@ type NextJobResponse struct {
 }
 
 type Job struct {
-	JobID       string   `json:"job_id"`
-	Type        string   `json:"type"`
-	Packages    []string `json:"packages,omitempty"`
-	ServiceName string   `json:"service_name,omitempty"`
-	Action      string   `json:"action,omitempty"`
-	PackageName string   `json:"package_name,omitempty"`
-	Refresh     bool     `json:"refresh,omitempty"`
-	CVE         string   `json:"cve,omitempty"`
-	Port        int      `json:"port,omitempty"`
-	Protocol    string   `json:"protocol,omitempty"`
-	Source      string   `json:"source,omitempty"`
-	Service     string   `json:"service,omitempty"`
+	JobID          string   `json:"job_id"`
+	Type           string   `json:"type"`
+	Packages       []string `json:"packages,omitempty"`
+	ServiceName    string   `json:"service_name,omitempty"`
+	Action         string   `json:"action,omitempty"`
+	PackageName    string   `json:"package_name,omitempty"`
+	Refresh        bool     `json:"refresh,omitempty"`
+	CVE            string   `json:"cve,omitempty"`
+	Port           int      `json:"port,omitempty"`
+	Protocol       string   `json:"protocol,omitempty"`
+	Source         string   `json:"source,omitempty"`
+	Service        string   `json:"service,omitempty"`
+	DryRun         bool     `json:"dry_run,omitempty"`
+	CleanupActions []string `json:"cleanup_actions,omitempty"`
 }
 
 type JobEvent struct {
@@ -110,13 +116,14 @@ func main() {
 	hostname, _ := os.Hostname()
 
 	reg := RegisterPayload{
-		AgentID:   cfg.AgentID,
-		Hostname:  hostname,
-		IPs:       localIPv4Addresses(),
-		Labels:    cfg.Labels,
-		OSID:      readOSID(),
-		OSVersion: readOSVersion(),
-		Kernel:    readKernel(),
+		AgentID:      cfg.AgentID,
+		Hostname:     hostname,
+		IPs:          localIPv4Addresses(),
+		Labels:       cfg.Labels,
+		OSID:         readOSID(),
+		OSVersion:    readOSVersion(),
+		Kernel:       readKernel(),
+		AgentVersion: AgentVersion,
 	}
 
 	lastRegisterAttempt := time.Time{}
@@ -143,7 +150,7 @@ func main() {
 		t := time.NewTicker(cfg.HbEvery)
 		defer t.Stop()
 		for {
-			req, _ := http.NewRequest("POST", cfg.ServerURL+"/agent/heartbeat?agent_id="+cfg.AgentID, nil)
+			req, _ := http.NewRequest("POST", cfg.ServerURL+"/agent/heartbeat?agent_id="+url.QueryEscape(cfg.AgentID)+"&agent_version="+url.QueryEscape(AgentVersion), nil)
 			if cfg.AgentToken != "" {
 				req.Header.Set("X-Fleet-Agent-Token", cfg.AgentToken)
 			}
@@ -663,6 +670,20 @@ func handleJob(ctx context.Context, client *http.Client, serverURL, agentID stri
 		mustPostJSON(client, serverURL+"/agent/job-event", ev, token)
 		return
 
+	case "disk-cleanup":
+		stdout, stderr, code, errMsg := runDiskCleanup(ctx, job.DryRun, job.CleanupActions)
+		if code == 0 && errMsg == "" {
+			ev.Status = "success"
+		} else {
+			ev.Status = "failed"
+		}
+		ev.ExitCode = &code
+		ev.Stdout = stdout
+		ev.Stderr = stderr
+		ev.Error = errMsg
+		mustPostJSON(client, serverURL+"/agent/job-event", ev, token)
+		return
+
 	case "query-service-details":
 		name := strings.TrimSpace(job.ServiceName)
 		if name == "" {
@@ -787,6 +808,249 @@ func queryDf(ctx context.Context) (string, string, int, string) {
 	}
 
 	return string(out), "", 0, ""
+}
+
+type DiskCleanupActionResult struct {
+	Key              string `json:"key"`
+	Label            string `json:"label"`
+	Status           string `json:"status"`
+	ReclaimableBytes int64  `json:"reclaimable_bytes,omitempty"`
+	ReclaimableHuman string `json:"reclaimable_human,omitempty"`
+	Detail           string `json:"detail,omitempty"`
+	Stdout           string `json:"stdout,omitempty"`
+	Stderr           string `json:"stderr,omitempty"`
+}
+
+func runDiskCleanup(ctx context.Context, dryRun bool, requested []string) (string, string, int, string) {
+	allowed := map[string]bool{
+		"apt_cache":      true,
+		"dnf_cache":      true,
+		"journald":       true,
+		"user_cache_old": true,
+	}
+	defaults := []string{"apt_cache", "dnf_cache", "journald", "user_cache_old"}
+	actions := make([]string, 0, len(requested))
+	seen := map[string]bool{}
+	for _, a := range requested {
+		a = strings.TrimSpace(a)
+		if a == "" {
+			continue
+		}
+		if !allowed[a] {
+			return "", "", 1, "unsupported cleanup action: " + a
+		}
+		if !seen[a] {
+			seen[a] = true
+			actions = append(actions, a)
+		}
+	}
+	if len(actions) == 0 {
+		actions = defaults
+	}
+
+	results := make([]DiskCleanupActionResult, 0, len(actions))
+	for _, action := range actions {
+		switch action {
+		case "apt_cache":
+			results = append(results, cleanupAptCache(ctx, dryRun))
+		case "dnf_cache":
+			results = append(results, cleanupDnfCache(ctx, dryRun))
+		case "journald":
+			results = append(results, cleanupJournald(ctx, dryRun))
+		case "user_cache_old":
+			results = append(results, cleanupOldUserCache(ctx, dryRun))
+		}
+	}
+
+	total := int64(0)
+	for _, r := range results {
+		total += r.ReclaimableBytes
+	}
+	payload := map[string]any{
+		"dry_run":                 dryRun,
+		"actions":                 results,
+		"total_reclaimable_bytes": total,
+		"total_reclaimable_human": formatBytes(total),
+		"note":                    "Dry run estimates cache space. Actual reclaimed space can differ after cleanup.",
+	}
+	b, err := json.Marshal(payload)
+	if err != nil {
+		return "", "", 1, fmt.Sprintf("JSON marshal failed: %v", err)
+	}
+	return string(b), "", 0, ""
+}
+
+func cleanupAptCache(ctx context.Context, dryRun bool) DiskCleanupActionResult {
+	r := DiskCleanupActionResult{Key: "apt_cache", Label: "APT package cache"}
+	if _, err := exec.LookPath("apt-get"); err != nil {
+		r.Status = "skipped"
+		r.Detail = "apt-get not found"
+		return r
+	}
+	size := dirSizeBytes(ctx, "/var/cache/apt")
+	r.ReclaimableBytes = size
+	r.ReclaimableHuman = formatBytes(size)
+	if dryRun {
+		r.Status = "ok"
+		r.Detail = "Would run apt-get clean"
+		return r
+	}
+	stdout, stderr, code, errMsg := runCleanupCommand(ctx, 60*time.Second, "apt-get", "clean")
+	r.Stdout, r.Stderr = stdout, stderr
+	if code == 0 && errMsg == "" {
+		r.Status = "ok"
+		r.Detail = "Ran apt-get clean"
+	} else {
+		r.Status = "failed"
+		r.Detail = errMsg
+	}
+	return r
+}
+
+func cleanupDnfCache(ctx context.Context, dryRun bool) DiskCleanupActionResult {
+	r := DiskCleanupActionResult{Key: "dnf_cache", Label: "DNF/YUM package cache"}
+	frontend := rpmFrontend()
+	if frontend == "" {
+		r.Status = "skipped"
+		r.Detail = "dnf/yum not found"
+		return r
+	}
+	size := dirSizeBytes(ctx, "/var/cache/dnf") + dirSizeBytes(ctx, "/var/cache/yum")
+	r.ReclaimableBytes = size
+	r.ReclaimableHuman = formatBytes(size)
+	if dryRun {
+		r.Status = "ok"
+		r.Detail = "Would run " + frontend + " clean all"
+		return r
+	}
+	stdout, stderr, code, errMsg := runCleanupCommand(ctx, 90*time.Second, frontend, "clean", "all")
+	r.Stdout, r.Stderr = stdout, stderr
+	if code == 0 && errMsg == "" {
+		r.Status = "ok"
+		r.Detail = "Ran " + frontend + " clean all"
+	} else {
+		r.Status = "failed"
+		r.Detail = errMsg
+	}
+	return r
+}
+
+func cleanupJournald(ctx context.Context, dryRun bool) DiskCleanupActionResult {
+	r := DiskCleanupActionResult{Key: "journald", Label: "systemd journal"}
+	if _, err := exec.LookPath("journalctl"); err != nil {
+		r.Status = "skipped"
+		r.Detail = "journalctl not found"
+		return r
+	}
+	if dryRun {
+		stdout, stderr, code, errMsg := runCleanupCommand(ctx, 15*time.Second, "journalctl", "--disk-usage", "--no-pager")
+		r.Stdout, r.Stderr = stdout, stderr
+		if code == 0 && errMsg == "" {
+			r.Status = "ok"
+			r.Detail = strings.TrimSpace(stdout)
+		} else {
+			r.Status = "failed"
+			r.Detail = errMsg
+		}
+		return r
+	}
+	stdout, stderr, code, errMsg := runCleanupCommand(ctx, 60*time.Second, "journalctl", "--vacuum-size=500M")
+	r.Stdout, r.Stderr = stdout, stderr
+	if code == 0 && errMsg == "" {
+		r.Status = "ok"
+		r.Detail = "Vacuumed journal to 500M"
+	} else {
+		r.Status = "failed"
+		r.Detail = errMsg
+	}
+	return r
+}
+
+func cleanupOldUserCache(ctx context.Context, dryRun bool) DiskCleanupActionResult {
+	r := DiskCleanupActionResult{Key: "user_cache_old", Label: "User cache files older than 14 days"}
+	if _, err := os.Stat("/home"); err != nil {
+		r.Status = "skipped"
+		r.Detail = "/home not found"
+		return r
+	}
+	count, size := oldUserCacheStats(ctx)
+	r.ReclaimableBytes = size
+	r.ReclaimableHuman = formatBytes(size)
+	if dryRun {
+		r.Status = "ok"
+		r.Detail = fmt.Sprintf("Would delete %d file(s) under /home/*/.cache older than 14 days", count)
+		return r
+	}
+	script := "find /home -path '*/.cache/*' -type f -mtime +14 -delete 2>/dev/null"
+	stdout, stderr, code, errMsg := runCleanupShell(ctx, 120*time.Second, script)
+	r.Stdout, r.Stderr = stdout, stderr
+	if code == 0 && errMsg == "" {
+		r.Status = "ok"
+		r.Detail = fmt.Sprintf("Deleted cache files older than 14 days; estimated before cleanup: %d file(s), %s", count, formatBytes(size))
+	} else {
+		r.Status = "failed"
+		r.Detail = errMsg
+	}
+	return r
+}
+
+func oldUserCacheStats(ctx context.Context) (int64, int64) {
+	script := "find /home -path '*/.cache/*' -type f -mtime +14 -printf '%s\\n' 2>/dev/null | awk '{n++; s+=$1} END {printf \"%d %d\\n\", n, s+0}'"
+	stdout, _, code, _ := runCleanupShell(ctx, 45*time.Second, script)
+	if code != 0 {
+		return 0, 0
+	}
+	fields := strings.Fields(stdout)
+	if len(fields) < 2 {
+		return 0, 0
+	}
+	count, _ := strconv.ParseInt(fields[0], 10, 64)
+	size, _ := strconv.ParseInt(fields[1], 10, 64)
+	return count, size
+}
+
+func dirSizeBytes(ctx context.Context, path string) int64 {
+	if _, err := os.Stat(path); err != nil {
+		return 0
+	}
+	stdout, _, code, _ := runCleanupCommand(ctx, 15*time.Second, "du", "-sb", path)
+	if code != 0 {
+		return 0
+	}
+	fields := strings.Fields(stdout)
+	if len(fields) == 0 {
+		return 0
+	}
+	n, _ := strconv.ParseInt(fields[0], 10, 64)
+	return n
+}
+
+func runCleanupCommand(ctx context.Context, timeout time.Duration, name string, args ...string) (string, string, int, string) {
+	queryCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	cmd := exec.CommandContext(queryCtx, name, args...)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	code := 0
+	errMsg := ""
+	if err != nil {
+		code = 1
+		if ee, ok := err.(*exec.ExitError); ok {
+			code = ee.ExitCode()
+		}
+		errMsg = err.Error()
+	}
+	if queryCtx.Err() == context.DeadlineExceeded {
+		code = 124
+		errMsg = "command timed out"
+	}
+	return stdout.String(), stderr.String(), code, errMsg
+}
+
+func runCleanupShell(ctx context.Context, timeout time.Duration, script string) (string, string, int, string) {
+	return runCleanupCommand(ctx, timeout, "sh", "-c", script)
 }
 
 func queryServiceDetails(ctx context.Context, serviceName string) (string, string, int, string) {

--- a/agent/cmd/fleet-agent/main_test.go
+++ b/agent/cmd/fleet-agent/main_test.go
@@ -1,7 +1,9 @@
 package main
 
 import (
+	"context"
 	"reflect"
+	"strings"
 	"testing"
 )
 
@@ -266,5 +268,15 @@ func TestBuildFirewalldRejectRule(t *testing.T) {
 	want := `rule family="ipv4" source address="10.0.0.0/8" port port="443" protocol="tcp" reject`
 	if got != want {
 		t.Fatalf("rich rule = %q, want %q", got, want)
+	}
+}
+
+func TestRunDiskCleanupRejectsUnsupportedAction(t *testing.T) {
+	_, _, code, errMsg := runDiskCleanup(context.Background(), true, []string{"wipe-everything"})
+	if code == 0 {
+		t.Fatal("runDiskCleanup returned success for unsupported action")
+	}
+	if !strings.Contains(errMsg, "unsupported cleanup action") {
+		t.Fatalf("error = %q, want unsupported cleanup action", errMsg)
 	}
 }

--- a/server/alembic/versions/20260615_00_agent_version.py
+++ b/server/alembic/versions/20260615_00_agent_version.py
@@ -1,0 +1,23 @@
+"""add agent version to hosts
+
+Revision ID: 20260615_00
+Revises: 20260505_01
+Create Date: 2026-06-15
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "20260615_00"
+down_revision = "20260505_01"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("hosts", sa.Column("agent_version", sa.String(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("hosts", "agent_version")

--- a/server/app/models.py
+++ b/server/app/models.py
@@ -14,6 +14,7 @@ class Host(Base):
     os_id = Column(String)
     os_version = Column(String)
     kernel = Column(String)
+    agent_version = Column(String)
     labels = Column(JSON, nullable=False, default=dict)
     last_seen = Column(DateTime(timezone=True))
     reboot_required = Column(Boolean, nullable=False, default=False)

--- a/server/app/routers/agent.py
+++ b/server/app/routers/agent.py
@@ -50,6 +50,7 @@ def agent_register(payload: AgentRegister, request: Request, db: Session = Depen
             "os_id": payload.os_id,
             "os_version": payload.os_version,
             "kernel": payload.kernel,
+            "agent_version": payload.agent_version,
             "labels": payload.labels or {},
             "last_seen": now,
         }
@@ -65,6 +66,8 @@ def agent_register(payload: AgentRegister, request: Request, db: Session = Depen
         host.os_id = payload.os_id
         host.os_version = payload.os_version
         host.kernel = payload.kernel
+        if payload.agent_version:
+            host.agent_version = payload.agent_version
 
         # Preserve UI-managed metadata (e.g. role/env) when agent re-registers without labels.
         existing_labels = dict(host.labels or {}) if isinstance(host.labels, dict) else {}
@@ -83,7 +86,12 @@ def agent_register(payload: AgentRegister, request: Request, db: Session = Depen
 
 
 @router.post("/heartbeat")
-def agent_heartbeat(agent_id: str, request: Request, db: Session = Depends(get_db)):
+def agent_heartbeat(
+    request: Request,
+    agent_id: str,
+    agent_version: str | None = None,
+    db: Session = Depends(get_db),
+):
     require_agent_token(request)
     host = db.execute(select(Host).where(Host.agent_id == agent_id)).scalar_one_or_none()
     if not host:
@@ -92,6 +100,9 @@ def agent_heartbeat(agent_id: str, request: Request, db: Session = Depends(get_d
     client_ip = get_client_ip(request)
     if client_ip and hasattr(host, "ip_address") and not host.ip_address:
         host.ip_address = client_ip
+
+    if agent_version:
+        host.agent_version = agent_version
 
     host.last_seen = datetime.now(timezone.utc)
     db.commit()
@@ -215,6 +226,13 @@ async def agent_next_job(agent_id: str, request: Request, db: Session = Depends(
             return {"job_id": job_row.job_key, "type": "inventory-now"}
         if t == "query-pkg-version":
             return {"job_id": job_row.job_key, "type": "query-pkg-version", "packages": payload.get("packages") or []}
+        if t == "disk-cleanup":
+            return {
+                "job_id": job_row.job_key,
+                "type": "disk-cleanup",
+                "dry_run": bool(payload.get("dry_run", True)),
+                "cleanup_actions": payload.get("actions") or [],
+            }
         if t == "pkg-upgrade":
             packages = payload.get("packages") or []
             by = payload.get("packages_by_agent") or {}

--- a/server/app/routers/hosts.py
+++ b/server/app/routers/hosts.py
@@ -20,7 +20,7 @@ from ..services.rbac import permissions_for
 from ..services.user_scopes import is_host_visible_to_user
 from ..services.package_names import sanitize_package_list
 from ..services.deb_version import is_vulnerable
-from ..schemas import FirewallRuleRequest, HostMetadataUpdate
+from ..schemas import DiskCleanupRequest, FirewallRuleRequest, HostMetadataUpdate
 
 router = APIRouter(prefix="/hosts", tags=["hosts"])
 
@@ -76,8 +76,10 @@ def list_hosts(online_only: bool = False, db: Session = Depends(get_db), user=De
             "os_id": h.os_id,
             "os_version": h.os_version,
             "kernel": h.kernel,
+            "agent_version": getattr(h, "agent_version", None),
             "labels": h.labels,
             "last_seen": h.last_seen,
+            "last_seen_seconds_ago": seconds_since_seen(h),
             "reboot_required": bool(getattr(h, "reboot_required", False)),
             "is_online": is_host_online(h, now),
         }
@@ -389,6 +391,17 @@ def host_drift(
             "status": "pass" if online else "warn",
             "severity": "ok" if online else "critical",
             "detail": "Host heartbeat is healthy" if online else "Host is offline/stale",
+        },
+        {
+            "key": "agent_version",
+            "title": "Agent version",
+            "status": "pass" if str(getattr(host, "agent_version", "") or "").strip() else "warn",
+            "severity": "ok" if str(getattr(host, "agent_version", "") or "").strip() else "warn",
+            "detail": (
+                f"Agent version {host.agent_version}"
+                if str(getattr(host, "agent_version", "") or "").strip()
+                else "Agent has not reported a version yet"
+            ),
         },
         {
             "key": "inventory_freshness",
@@ -1543,6 +1556,104 @@ async def get_df(agent_id: str, wait: bool = True, db: Session = Depends(get_db)
         raise HTTPException(500, f"df query failed: {msg}")
 
     return {"stdout": run.stdout or ""}
+
+
+@router.post("/{agent_id}/disk-cleanup")
+async def disk_cleanup_host(
+    agent_id: str,
+    payload: DiskCleanupRequest,
+    request: Request,
+    wait: bool = True,
+    db: Session = Depends(get_db),
+    user=Depends(require_ui_user),
+):
+    perms = permissions_for(user)
+    if not perms.get("can_manage_packages"):
+        raise HTTPException(403, "Insufficient permissions to run disk cleanup")
+
+    host = db.execute(select(Host).where(Host.agent_id == agent_id)).scalar_one_or_none()
+    if not host or not is_host_visible_to_user(db, user, host):
+        raise HTTPException(404, "Host not found")
+
+    if not is_host_online(host):
+        t = seconds_since_seen(host)
+        if t is not None:
+            raise HTTPException(503, f"Agent appears offline (last seen {int(t)}s ago)")
+        raise HTTPException(503, "Agent appears offline")
+
+    allowed_actions = {"apt_cache", "dnf_cache", "journald", "user_cache_old"}
+    actions = []
+    seen = set()
+    for raw in payload.actions or []:
+        action = str(raw or "").strip()
+        if not action:
+            continue
+        if action not in allowed_actions:
+            raise HTTPException(400, f"Unsupported cleanup action: {action}")
+        if action not in seen:
+            seen.add(action)
+            actions.append(action)
+
+    if not actions:
+        actions = ["apt_cache", "dnf_cache", "journald", "user_cache_old"]
+
+    with transaction(db):
+        created = create_job_with_runs(
+            db=db,
+            job_type="disk-cleanup",
+            payload={"dry_run": bool(payload.dry_run), "actions": actions},
+            agent_ids=[agent_id],
+            commit=False,
+            created_by=getattr(user, "username", None) or "api",
+        )
+
+        try:
+            log_event(
+                db,
+                action="hosts.disk_cleanup.dry_run" if payload.dry_run else "hosts.disk_cleanup.apply",
+                actor=user,
+                request=request,
+                target_type="host",
+                target_id=str(agent_id),
+                target_name=str(getattr(host, "hostname", None) or agent_id),
+                meta={"job_id": created.job_key, "dry_run": bool(payload.dry_run), "actions": actions},
+            )
+        except Exception:
+            pass
+
+    job_id = created.job.id
+
+    await push_job_to_agents(
+        agent_ids=[agent_id],
+        job_payload_builder=lambda aid: {
+            "job_id": created.job_key,
+            "type": "disk-cleanup",
+            "dry_run": bool(payload.dry_run),
+            "cleanup_actions": actions,
+        },
+    )
+
+    if not wait:
+        return {"job_id": created.job_key, "status": "queued", "dry_run": bool(payload.dry_run), "actions": actions}
+
+    timeout = 45
+    res = await wait_for_job_run(job_id=job_id, agent_id=agent_id, timeout_s=timeout, poll_interval_s=0.3)
+    if not res.run:
+        raise HTTPException(504, f"Timeout waiting for disk cleanup after {timeout}s")
+
+    run = res.run
+    if run.status == "failed":
+        msg = run.error or run.stderr or run.stdout or "Unknown error"
+        raise HTTPException(500, f"Disk cleanup failed: {msg}")
+
+    from ..services.json_utils import loads_or
+
+    result = loads_or(run.stdout, {})
+    if not isinstance(result, dict):
+        result = {"stdout": run.stdout or ""}
+    result.setdefault("job_id", created.job_key)
+    result.setdefault("status", "success")
+    return result
 
 
 @router.get("/{agent_id}/metrics")

--- a/server/app/schemas.py
+++ b/server/app/schemas.py
@@ -9,6 +9,7 @@ class AgentRegister(BaseModel):
     os_id: Optional[str] = None
     os_version: Optional[str] = None
     kernel: Optional[str] = None
+    agent_version: Optional[str] = None
     labels: Dict[str,str] = Field(default_factory=dict)
 
 class PackagesInventory(BaseModel):
@@ -52,6 +53,11 @@ class JobCreateDistUpgrade(BaseModel):
     agent_ids: Optional[List[str]] = None
     labels: Optional[Dict[str,str]] = None
     dry_run: bool = False
+
+
+class DiskCleanupRequest(BaseModel):
+    dry_run: bool = True
+    actions: List[str] = Field(default_factory=list)
 
 
 class JobPreflightRequest(BaseModel):

--- a/server/app/services/hosts.py
+++ b/server/app/services/hosts.py
@@ -13,7 +13,10 @@ def is_host_online(host: Host, now: datetime | None = None) -> bool:
     if now is None:
         now = datetime.now(timezone.utc)
     try:
-        return (now - host.last_seen).total_seconds() <= settings.agent_online_grace_seconds
+        last_seen = host.last_seen
+        if getattr(last_seen, "tzinfo", None) is None:
+            last_seen = last_seen.replace(tzinfo=timezone.utc)
+        return (now - last_seen).total_seconds() <= settings.agent_online_grace_seconds
     except Exception:
         return False
 
@@ -24,7 +27,10 @@ def seconds_since_seen(host: Host, now: datetime | None = None) -> float | None:
     if now is None:
         now = datetime.now(timezone.utc)
     try:
-        return (now - host.last_seen).total_seconds()
+        last_seen = host.last_seen
+        if getattr(last_seen, "tzinfo", None) is None:
+            last_seen = last_seen.replace(tzinfo=timezone.utc)
+        return (now - last_seen).total_seconds()
     except Exception:
         return None
 

--- a/server/app/templates/fleet-phase3-host-actions.js
+++ b/server/app/templates/fleet-phase3-host-actions.js
@@ -79,6 +79,93 @@
     if (statusEl) statusEl.textContent = '';
   }
 
+  function populateDiskCleanupPanel(host) {
+    const statusEl = document.getElementById('disk-cleanup-status');
+    const outputEl = document.getElementById('disk-cleanup-output');
+    if (statusEl) {
+      const online = host?.is_online ? 'Ready' : 'Agent offline';
+      statusEl.textContent = online;
+    }
+    if (outputEl) {
+      outputEl.style.display = 'none';
+      outputEl.textContent = '';
+    }
+  }
+
+  function formatDiskCleanupResult(data) {
+    const lines = [];
+    const dryRun = !!data?.dry_run;
+    lines.push((dryRun ? 'Dry run' : 'Cleanup complete') + ': estimated reclaimable ' + (data?.total_reclaimable_human || '0B'));
+    const actions = Array.isArray(data?.actions) ? data.actions : [];
+    actions.forEach((item) => {
+      const label = item?.label || item?.key || 'action';
+      const status = item?.status || 'unknown';
+      const reclaim = item?.reclaimable_human ? ' · ' + item.reclaimable_human : '';
+      const detail = item?.detail ? ' · ' + item.detail : '';
+      lines.push('- ' + label + ': ' + status + reclaim + detail);
+    });
+    if (data?.note) lines.push('', data.note);
+    return lines.join('\n');
+  }
+
+  function initDiskCleanupControls(ctx) {
+    const api = ctx || {};
+    const dryBtn = document.getElementById('disk-cleanup-dry-run');
+    const applyBtn = document.getElementById('disk-cleanup-apply');
+    const statusEl = document.getElementById('disk-cleanup-status');
+    const outputEl = document.getElementById('disk-cleanup-output');
+
+    async function runCleanup(dryRun) {
+      const agentId = (typeof api.getCurrentAgentId === 'function') ? api.getCurrentAgentId() : null;
+      if (!agentId) return;
+      if (!dryRun && !confirm('Run safe disk cleanup on this host now?')) return;
+
+      const buttons = [dryBtn, applyBtn].filter(Boolean);
+      try {
+        buttons.forEach((btn) => { btn.disabled = true; });
+        if (statusEl) statusEl.textContent = dryRun ? 'Checking cleanup…' : 'Running cleanup…';
+        if (outputEl) {
+          outputEl.style.display = 'block';
+          outputEl.textContent = '';
+        }
+        const r = await fetch(`/hosts/${encodeURIComponent(agentId)}/disk-cleanup?wait=true`, {
+          method: 'POST',
+          credentials: 'include',
+          headers: {
+            'content-type': 'application/json',
+            'X-CSRF-Token': (typeof w.getCookie === 'function' ? (w.getCookie('fleet_csrf') || '') : ''),
+          },
+          body: JSON.stringify({ dry_run: !!dryRun }),
+        });
+        const raw = await r.text();
+        let data = null; try { data = raw ? JSON.parse(raw) : null; } catch {}
+        if (!r.ok) throw new Error((data && (data.detail || data.error)) || raw || `Cleanup failed (${r.status})`);
+        if (outputEl) outputEl.textContent = formatDiskCleanupResult(data || {});
+        if (statusEl) statusEl.textContent = dryRun ? 'Dry run complete.' : 'Cleanup complete.';
+        if (typeof w.showToast === 'function') w.showToast(dryRun ? 'Disk cleanup dry run complete' : 'Disk cleanup complete', 'success');
+      } catch (err) {
+        const msg = err?.message || String(err);
+        if (statusEl) statusEl.textContent = msg;
+        if (outputEl) {
+          outputEl.style.display = 'block';
+          outputEl.textContent = msg;
+        }
+        if (typeof w.showToast === 'function') w.showToast(msg, 'error');
+      } finally {
+        buttons.forEach((btn) => { btn.disabled = false; });
+      }
+    }
+
+    dryBtn?.addEventListener('click', (e) => {
+      e.preventDefault();
+      runCleanup(true);
+    });
+    applyBtn?.addEventListener('click', (e) => {
+      e.preventDefault();
+      runCleanup(false);
+    });
+  }
+
   function normalizeHostMetadataPayload(input) {
     const src = input || {};
     const envIn = (src.env && typeof src.env === 'object') ? src.env : {};
@@ -172,6 +259,8 @@
     normalizeHostMetadataPayload: normalizeHostMetadataPayload,
     initHostMetadataEditor: initHostMetadataEditor,
     populateHostMetadataEditor: populateHostMetadataEditor,
+    populateDiskCleanupPanel: populateDiskCleanupPanel,
+    initDiskCleanupControls: initDiskCleanupControls,
     initCommonModalDismissHandlers: initCommonModalDismissHandlers,
   };
 })(window);

--- a/server/app/templates/fleet-phase3-overview.js
+++ b/server/app/templates/fleet-phase3-overview.js
@@ -412,6 +412,7 @@
       const owner = String(it?.labels?.owner || '').trim();
       const os = `${it.os_id || ''} ${it.os_version || ''}`.trim() || '–';
       const kernel = it.kernel || '–';
+      const agentVersion = it.agent_version || 'unknown';
       const sec = Number(it.security_updates || 0);
       const all = Number(it.updates || 0);
       const online = it.is_online ? '<span class="status-ok">online</span>' : '<span class="status-error">offline</span>';
@@ -443,7 +444,7 @@
           <div style="display:flex;align-items:center;justify-content:space-between;gap:0.5rem;">
             <b>${w.escapeHtml(hostName)}</b>
           </div>
-          <div style="color:var(--muted-2);font-size:0.85rem;">${w.escapeHtml(it.agent_id || '')} ${it.ip_address ? '• ' + w.escapeHtml(it.ip_address) : ''}</div>
+          <div style="color:var(--muted-2);font-size:0.85rem;">${w.escapeHtml(it.agent_id || '')} ${it.ip_address ? '• ' + w.escapeHtml(it.ip_address) : ''} • agent ${w.escapeHtml(agentVersion)}</div>
         </td>
         <td>${owner ? `<code>${w.escapeHtml(owner)}</code>` : '<span class="status-muted">—</span>'}</td>
         <td>${w.escapeHtml(os)}</td>

--- a/server/app/templates/index.html
+++ b/server/app/templates/index.html
@@ -120,6 +120,18 @@
                   </div>
                 </div>
               </div>
+              <div class="admin-card host-disk-cleanup-card" style="margin-top:0;max-width:760px;">
+                <div class="admin-card-title">Disk cleanup</div>
+                <div class="admin-card-body" style="display:grid;gap:0.55rem;">
+                  <div class="status-muted" style="font-size:0.86rem;">Safe cleanup covers package caches, journald vacuum to 500M, and /home user cache files older than 14 days.</div>
+                  <div style="display:flex;gap:0.45rem;flex-wrap:wrap;">
+                    <button class="btn" id="disk-cleanup-dry-run" type="button">Dry run</button>
+                    <button class="btn btn-warning" id="disk-cleanup-apply" type="button">Run cleanup</button>
+                    <span id="disk-cleanup-status" class="status-muted" role="status" aria-live="polite" style="font-size:0.85rem;"></span>
+                  </div>
+                  <pre id="disk-cleanup-output" class="terminal-output" style="display:none;max-height:220px;overflow:auto;white-space:pre-wrap;margin:0;"></pre>
+                </div>
+              </div>
             </div>
 
             <div class="metrics-grid">
@@ -1977,6 +1989,8 @@
         const osText = osParts.length ? escapeHtml(osParts.join(' ')) : 'n/a';
         detailsEl.innerHTML = `
           <span class="detail-pill">Agent ID: <code>${agentText}</code></span>
+          <span class="detail-pill">Agent: <code>${escapeHtml(hostObj?.agent_version || 'unknown')}</code></span>
+          <span class="detail-pill">Health: <code>${hostObj?.is_online ? 'online' : 'offline'}</code></span>
           <span class="detail-pill">OS: <code>${osText}</code></span>
         `;
       }
@@ -1996,6 +2010,9 @@
         const hostActionsMod = window.phase3HostActions;
         if (hostActionsMod && typeof hostActionsMod.populateHostMetadataEditor === 'function') {
           hostActionsMod.populateHostMetadataEditor(hostObj || { agent_id: agentId, hostname });
+        }
+        if (hostActionsMod && typeof hostActionsMod.populateDiskCleanupPanel === 'function') {
+          hostActionsMod.populateDiskCleanupPanel(hostObj || { agent_id: agentId, hostname });
         }
       } catch (_) { }
 
@@ -4655,6 +4672,15 @@
       }
     }
 
+    function initDiskCleanupControls() {
+      const mod = window.phase3HostActions;
+      if (mod && typeof mod.initDiskCleanupControls === 'function') {
+        return mod.initDiskCleanupControls({
+          getCurrentAgentId: () => currentAgentId,
+        });
+      }
+    }
+
     function getSshUiCtx() {
       return {
         loadSshKeys,
@@ -5490,6 +5516,7 @@
       safeInit('initHostActionControls', initHostActionControls);
       safeInit('initHostFirewallControls', initHostFirewallControls);
       safeInit('initHostMetadataEditor', initHostMetadataEditor);
+      safeInit('initDiskCleanupControls', initDiskCleanupControls);
       safeInit('initAuditDetailModalControls', initAuditDetailModalControls);
       safeInit('initApprovalDetailModalControls', initApprovalDetailModalControls);
       safeInit('initFailedRunDetailModalControls', initFailedRunDetailModalControls);

--- a/server/app/version.py
+++ b/server/app/version.py
@@ -1,1 +1,1 @@
-APP_VERSION = "0.0.2-alpha"
+APP_VERSION = "0.0.3-alpha"

--- a/server/tests/test_disk_cleanup_and_agent_health.py
+++ b/server/tests/test_disk_cleanup_and_agent_health.py
@@ -1,0 +1,70 @@
+import importlib
+import sys
+
+
+def _reload_app_modules():
+    for k in list(sys.modules.keys()):
+        if k == "app" or k.startswith("app."):
+            sys.modules.pop(k, None)
+
+
+def _login_admin(client):
+    r = client.post("/auth/login", json={"username": "admin", "password": "admin-password-123"})
+    assert r.status_code == 200, r.text
+    csrf = client.cookies.get("fleet_csrf")
+    return {"X-CSRF-Token": csrf} if csrf else {}
+
+
+def test_agent_version_is_listed_and_disk_cleanup_can_be_queued(monkeypatch):
+    monkeypatch.setenv("DATABASE_URL", "sqlite+pysqlite:///:memory:")
+    monkeypatch.setenv("BOOTSTRAP_USERNAME", "admin")
+    monkeypatch.setenv("BOOTSTRAP_PASSWORD", "admin-password-123")
+    monkeypatch.setenv("UI_COOKIE_SECURE", "false")
+    monkeypatch.setenv("ALLOW_INSECURE_NO_AGENT_TOKEN", "true")
+    monkeypatch.setenv("AGENT_SHARED_TOKEN", "")
+    monkeypatch.setenv("DB_AUTO_CREATE_TABLES", "true")
+    monkeypatch.setenv("DB_REQUIRE_MIGRATIONS_UP_TO_DATE", "false")
+    monkeypatch.setenv("MFA_REQUIRE_FOR_PRIVILEGED", "false")
+
+    _reload_app_modules()
+    app_factory = importlib.import_module("app.app_factory")
+    app = app_factory.create_app()
+
+    from fastapi.testclient import TestClient
+
+    with TestClient(app) as client:
+        r = client.post(
+            "/agent/register",
+            json={
+                "agent_id": "srv-health-001",
+                "hostname": "srv-health-001",
+                "os_id": "ubuntu",
+                "os_version": "24.04",
+                "kernel": "test",
+                "agent_version": "0.0.3-alpha",
+                "labels": {"env": "test", "role": "worker"},
+            },
+        )
+        assert r.status_code == 200, r.text
+
+        headers = _login_admin(client)
+
+        r = client.get("/hosts")
+        assert r.status_code == 200, r.text
+        hosts = r.json()
+        row = next(h for h in hosts if h["agent_id"] == "srv-health-001")
+        assert row["agent_version"] == "0.0.3-alpha"
+        assert row["is_online"] is True
+        assert isinstance(row["last_seen_seconds_ago"], (int, float))
+
+        r = client.post(
+            "/hosts/srv-health-001/disk-cleanup?wait=false",
+            json={"dry_run": True, "actions": ["apt_cache", "journald"]},
+            headers=headers,
+        )
+        assert r.status_code == 200, r.text
+        data = r.json()
+        assert data["status"] == "queued"
+        assert data["dry_run"] is True
+        assert data["actions"] == ["apt_cache", "journald"]
+        assert data["job_id"]


### PR DESCRIPTION
## Summary
- add agent version reporting on registration/heartbeat and surface it in host lists/details/health checks
- add safe disk cleanup dry-run/apply jobs for package caches, journald vacuum, and old `/home/*/.cache` files
- add a host overview cleanup card with dry-run and apply controls
- bump app and agent version to `0.0.3-alpha`

## Tests
- `.venv/bin/pytest server/tests -q`
- `npm run test:frontend`
- `go test ./...` in `agent/`
- `../.venv/bin/alembic heads` in `server/`
