### PR TITLE
Paginate dashboard attention hosts

### DIFF
--- a/server/app/templates/fleet-phase3-overview.js
+++ b/server/app/templates/fleet-phase3-overview.js
@@ -319,6 +319,39 @@
   }
 
   let hostsTableItemsCache = [];
+  let hostsTablePage = 1;
+
+  function getHostsTablePageSize() {
+    const raw = String(document.getElementById('hosts-page-size')?.value || '10').trim().toLowerCase();
+    if (raw === 'all') return Infinity;
+    const n = Number(raw);
+    return n === 50 ? 50 : 10;
+  }
+
+  function setHostsTablePage(page) {
+    const n = Number(page);
+    hostsTablePage = Number.isFinite(n) && n > 0 ? Math.floor(n) : 1;
+  }
+
+  function updateHostsTablePagination(filteredCount) {
+    const pageSize = getHostsTablePageSize();
+    const totalPages = pageSize === Infinity ? 1 : Math.max(1, Math.ceil(filteredCount / pageSize));
+    if (hostsTablePage > totalPages) hostsTablePage = totalPages;
+    if (hostsTablePage < 1) hostsTablePage = 1;
+
+    const prevBtn = document.getElementById('hosts-page-prev');
+    const nextBtn = document.getElementById('hosts-page-next');
+    const labelEl = document.getElementById('hosts-page-label');
+    if (prevBtn) prevBtn.disabled = hostsTablePage <= 1 || totalPages <= 1;
+    if (nextBtn) nextBtn.disabled = hostsTablePage >= totalPages || totalPages <= 1;
+    if (labelEl) labelEl.textContent = pageSize === Infinity ? 'All hosts' : `Page ${hostsTablePage} / ${totalPages}`;
+    return { pageSize, totalPages };
+  }
+
+  function moveHostsTablePage(ctx, delta) {
+    setHostsTablePage(hostsTablePage + Number(delta || 0));
+    applyHostsTableFilters(ctx);
+  }
 
   function filterHostsTableItems(ctx, items) {
     let out = Array.isArray(items) ? items.slice() : [];
@@ -356,26 +389,41 @@
     if (!tbody) return;
     const counterEl = document.getElementById('hosts-visible-counter');
     const total = Array.isArray(hostsTableItemsCache) ? hostsTableItemsCache.length : 0;
-    if (!items.length) {
+    const filteredItems = Array.isArray(items) ? items : [];
+    const filteredCount = filteredItems.length;
+    const { pageSize } = updateHostsTablePagination(filteredCount);
+    const pageItems = pageSize === Infinity
+      ? filteredItems
+      : filteredItems.slice((hostsTablePage - 1) * pageSize, hostsTablePage * pageSize);
+
+    if (!filteredCount) {
       if (counterEl) counterEl.textContent = `0 / ${total} hosts shown · online 0 · offline 0`;
       w.setTableState(tbody, 10, 'empty', 'No hosts match current filters');
       if (ctx && typeof ctx.setLastRenderedAgentIds === 'function') ctx.setLastRenderedAgentIds([]);
+      const selectAll = document.getElementById('hosts-select-all');
+      if (selectAll) {
+        selectAll.checked = false;
+        selectAll.indeterminate = false;
+      }
       return;
     }
 
     if (counterEl) {
-      const onlineCount = items.filter((it) => !!it.is_online).length;
-      const offlineCount = Math.max(0, items.length - onlineCount);
-      const withUpdates = items.filter((it) => Number(it.security_updates || 0) > 0 || Number(it.updates || 0) > 0).length;
-      counterEl.textContent = `${items.length} / ${total} hosts shown · online ${onlineCount} · offline ${offlineCount} · pending updates ${withUpdates}`;
+      const onlineCount = pageItems.filter((it) => !!it.is_online).length;
+      const offlineCount = Math.max(0, pageItems.length - onlineCount);
+      const withUpdates = pageItems.filter((it) => Number(it.security_updates || 0) > 0 || Number(it.updates || 0) > 0).length;
+      const start = pageSize === Infinity ? 1 : ((hostsTablePage - 1) * pageSize) + 1;
+      const end = pageSize === Infinity ? filteredCount : Math.min(filteredCount, hostsTablePage * pageSize);
+      const rangeText = filteredCount ? `${start}-${end}` : '0';
+      counterEl.textContent = `${rangeText} / ${filteredCount} filtered hosts shown · ${total} total · online ${onlineCount} · offline ${offlineCount} · pending updates ${withUpdates}`;
     }
 
     if (ctx && typeof ctx.setLastRenderedAgentIds === 'function') {
-      ctx.setLastRenderedAgentIds(items.map((it) => String(it.agent_id || '')).filter(Boolean));
+      ctx.setLastRenderedAgentIds(pageItems.map((it) => String(it.agent_id || '')).filter(Boolean));
     }
 
     tbody.innerHTML = '';
-    for (const it of items) {
+    for (const it of pageItems) {
       const hostName = it.hostname || it.agent_id;
       const owner = String(it?.labels?.owner || '').trim();
       const os = `${it.os_id || ''} ${it.os_version || ''}`.trim() || '–';
@@ -650,6 +698,15 @@
 
       tbody.appendChild(tr);
     }
+
+    const selectAll = document.getElementById('hosts-select-all');
+    if (selectAll) {
+      const selectedAgentIds = (ctx && ctx.getSelectedAgentIds && ctx.getSelectedAgentIds()) || new Set();
+      const visibleIds = pageItems.map((it) => String(it.agent_id || '')).filter(Boolean);
+      const selectedVisible = visibleIds.filter((aid) => selectedAgentIds.has(aid)).length;
+      selectAll.checked = visibleIds.length > 0 && selectedVisible === visibleIds.length;
+      selectAll.indeterminate = selectedVisible > 0 && selectedVisible < visibleIds.length;
+    }
   }
 
   document.addEventListener('click', () => {
@@ -717,6 +774,7 @@
       const d = await r.json();
       const items = d?.items || [];
       hostsTableItemsCache = Array.isArray(items) ? items : [];
+      setHostsTablePage(1);
       const currentAgentId = (ctx && typeof ctx.getCurrentAgentId === 'function') ? (ctx.getCurrentAgentId() || '') : '';
       if (currentAgentId && !hostsTableItemsCache.some((it) => String(it?.agent_id || '') === String(currentAgentId))) {
         if (ctx && typeof ctx.clearCurrentHostSelection === 'function') ctx.clearCurrentHostSelection();
@@ -1484,5 +1542,5 @@
     } catch (_) { }
   }
 
-  w.phase3Overview = { loadFleetOverview, loadHostsTable, applyHostsTableFilters, loadPendingUpdatesReport, initFleetOverviewControls };
+  w.phase3Overview = { loadFleetOverview, loadHostsTable, applyHostsTableFilters, setHostsTablePage, moveHostsTablePage, loadPendingUpdatesReport, initFleetOverviewControls };
 })(window);

--- a/server/app/templates/fleet-phase3-overview.js
+++ b/server/app/templates/fleet-phase3-overview.js
@@ -65,6 +65,116 @@
     return raw || fallback;
   }
 
+  let attentionItemsCache = [];
+  let attentionPage = 1;
+
+  function getAttentionPageSize() {
+    const raw = String(document.getElementById('overview-attention-page-size')?.value || '10').trim().toLowerCase();
+    if (raw === 'all') return Infinity;
+    const n = Number(raw);
+    return n === 50 ? 50 : 10;
+  }
+
+  function setAttentionPage(page) {
+    const n = Number(page);
+    attentionPage = Number.isFinite(n) && n > 0 ? Math.floor(n) : 1;
+  }
+
+  function updateAttentionPagination(totalCount) {
+    const pageSize = getAttentionPageSize();
+    const totalPages = pageSize === Infinity ? 1 : Math.max(1, Math.ceil(totalCount / pageSize));
+    if (attentionPage > totalPages) attentionPage = totalPages;
+    if (attentionPage < 1) attentionPage = 1;
+
+    const prevBtn = document.getElementById('overview-attention-page-prev');
+    const nextBtn = document.getElementById('overview-attention-page-next');
+    const labelEl = document.getElementById('overview-attention-page-label');
+    if (prevBtn) prevBtn.disabled = attentionPage <= 1 || totalPages <= 1;
+    if (nextBtn) nextBtn.disabled = attentionPage >= totalPages || totalPages <= 1;
+    if (labelEl) labelEl.textContent = pageSize === Infinity ? 'All hosts' : `Page ${attentionPage} / ${totalPages}`;
+    return { pageSize, totalPages };
+  }
+
+  function wireAttentionIssueLinks(ctx, attentionEl) {
+    attentionEl.querySelectorAll('a.attention-issue').forEach(a => {
+      a.addEventListener('click', (e) => {
+        e.preventDefault();
+        const aid = a.getAttribute('data-agent-id') || '';
+        const hostname = a.getAttribute('data-hostname') || aid;
+        const kind = a.getAttribute('data-kind') || '';
+        if (!aid) return;
+        ctx.selectHost(aid, hostname);
+        if (kind === 'disk') return ctx.openDiskModal(aid);
+        if (kind === 'cpu') {
+          ctx.showServerInfo();
+          document.getElementById('top-processes-body')?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+          return;
+        }
+        if (kind === 'security_updates' || kind === 'updates') {
+          ctx.showPackages();
+          const updatesOnlyEl = document.getElementById('packages-updates-only');
+          if (updatesOnlyEl) {
+            updatesOnlyEl.checked = true;
+            ctx.setPackagesUpdatesOnly(true);
+            ctx.loadPackages(aid);
+          }
+          return;
+        }
+        if (kind === 'reboot_required') {
+          w.showToast('Host reports reboot required', 'info');
+          return ctx.showServerInfo();
+        }
+        if (kind === 'offline') return w.showToast('Host appears offline', 'error');
+        ctx.showServerInfo();
+      });
+    });
+  }
+
+  function renderAttentionRows(ctx) {
+    const attentionEl = document.getElementById('overview-attention');
+    if (!attentionEl) return;
+    const counterEl = document.getElementById('overview-attention-counter');
+    const rows = Array.isArray(attentionItemsCache) ? attentionItemsCache : [];
+    const totalCount = rows.length;
+    const { pageSize } = updateAttentionPagination(totalCount);
+
+    if (!totalCount) {
+      if (counterEl) counterEl.textContent = '0 / 0 hosts shown';
+      attentionEl.innerHTML = '<div class="status-ok">All clear. No high-priority issues detected.</div>';
+      return;
+    }
+
+    const pageRows = pageSize === Infinity
+      ? rows
+      : rows.slice((attentionPage - 1) * pageSize, attentionPage * pageSize);
+    const start = pageSize === Infinity ? 1 : ((attentionPage - 1) * pageSize) + 1;
+    const end = pageSize === Infinity ? totalCount : Math.min(totalCount, attentionPage * pageSize);
+    if (counterEl) counterEl.textContent = `${start}-${end} / ${totalCount} hosts with issues shown`;
+
+    const html = [];
+    html.push('<div style="overflow:auto;max-width:100%;"><table class="process-table" style="width:100%;table-layout:fixed;"><thead><tr><th style="width:24%;">Host</th><th style="width:46%;">Issues</th><th style="width:30%;">Last seen</th></tr></thead><tbody>');
+    for (const it of pageRows) {
+      const agentId = String(it.agent_id || '');
+      const hostName = String(it.hostname || it.agent_id || '');
+      const host = w.escapeHtml(hostName);
+      const last = it.last_seen ? w.escapeHtml(formatShortTimeSafe(ctx, it.last_seen)) : '–';
+      const issuesHtml = (it.issues || []).map(x => {
+        const kind = String(x.kind || '');
+        const msg = String(x.message || '');
+        return `<a href="#" class="attention-issue" data-agent-id="${w.escapeHtml(agentId)}" data-hostname="${w.escapeHtml(hostName)}" data-kind="${w.escapeHtml(kind)}" style="text-decoration:underline;">${w.escapeHtml(msg)}</a>`;
+      }).join(', ');
+      html.push(`<tr><td style="font-family:monospace;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;">${host}</td><td style="white-space:normal;overflow-wrap:anywhere;word-break:break-word;line-height:1.35;">${issuesHtml || ''}</td><td style="color:var(--muted-2);white-space:normal;overflow-wrap:anywhere;">${last}</td></tr>`);
+    }
+    html.push('</tbody></table></div>');
+    attentionEl.innerHTML = html.join('');
+    wireAttentionIssueLinks(ctx, attentionEl);
+  }
+
+  function moveAttentionPage(ctx, delta) {
+    setAttentionPage(attentionPage + Number(delta || 0));
+    renderAttentionRows(ctx);
+  }
+
   async function loadFleetOverview(ctx, forceLive, backgroundRefresh) {
     const isBackgroundRefresh = !!backgroundRefresh;
     const onlineEl = document.getElementById('kpi-online');
@@ -230,59 +340,9 @@
           if (!r2.ok) throw await buildHttpError(r2, 'attention failed');
           const a = await r2.json();
           const rows = a?.items || [];
-          if (!rows.length) {
-            attentionEl.innerHTML = '<div class="status-ok">All clear. No high-priority issues detected.</div>';
-          } else {
-            const html = [];
-            html.push('<div style="overflow:auto;max-width:100%;"><table class="process-table" style="width:100%;table-layout:fixed;"><thead><tr><th style="width:24%;">Host</th><th style="width:46%;">Issues</th><th style="width:30%;">Last seen</th></tr></thead><tbody>');
-            for (const it of rows) {
-              const agentId = String(it.agent_id || '');
-              const hostName = String(it.hostname || it.agent_id || '');
-              const host = w.escapeHtml(hostName);
-              const last = it.last_seen ? w.escapeHtml(formatShortTimeSafe(ctx, it.last_seen)) : '–';
-              const issuesHtml = (it.issues || []).map(x => {
-                const kind = String(x.kind || '');
-                const msg = String(x.message || '');
-                return `<a href="#" class="attention-issue" data-agent-id="${w.escapeHtml(agentId)}" data-hostname="${w.escapeHtml(hostName)}" data-kind="${w.escapeHtml(kind)}" style="text-decoration:underline;">${w.escapeHtml(msg)}</a>`;
-              }).join(', ');
-              html.push(`<tr><td style="font-family:monospace;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;">${host}</td><td style="white-space:normal;overflow-wrap:anywhere;word-break:break-word;line-height:1.35;">${issuesHtml || ''}</td><td style="color:var(--muted-2);white-space:normal;overflow-wrap:anywhere;">${last}</td></tr>`);
-            }
-            html.push('</tbody></table></div>');
-            attentionEl.innerHTML = html.join('');
-
-            attentionEl.querySelectorAll('a.attention-issue').forEach(a => {
-              a.addEventListener('click', (e) => {
-                e.preventDefault();
-                const aid = a.getAttribute('data-agent-id') || '';
-                const hostname = a.getAttribute('data-hostname') || aid;
-                const kind = a.getAttribute('data-kind') || '';
-                if (!aid) return;
-                ctx.selectHost(aid, hostname);
-                if (kind === 'disk') return ctx.openDiskModal(aid);
-                if (kind === 'cpu') {
-                  ctx.showServerInfo();
-                  document.getElementById('top-processes-body')?.scrollIntoView({ behavior: 'smooth', block: 'start' });
-                  return;
-                }
-                if (kind === 'security_updates' || kind === 'updates') {
-                  ctx.showPackages();
-                  const updatesOnlyEl = document.getElementById('packages-updates-only');
-                  if (updatesOnlyEl) {
-                    updatesOnlyEl.checked = true;
-                    ctx.setPackagesUpdatesOnly(true);
-                    ctx.loadPackages(aid);
-                  }
-                  return;
-                }
-                if (kind === 'reboot_required') {
-                  w.showToast('Host reports reboot required', 'info');
-                  return ctx.showServerInfo();
-                }
-                if (kind === 'offline') return w.showToast('Host appears offline', 'error');
-                ctx.showServerInfo();
-              });
-            });
-          }
+          attentionItemsCache = Array.isArray(rows) ? rows : [];
+          if (!isBackgroundRefresh) setAttentionPage(1);
+          renderAttentionRows(ctx);
         } catch (e2) {
           attentionEl.innerHTML = `<div class="error">Attention list error: ${w.escapeHtml(e2.message || String(e2))}</div>`;
         }
@@ -1343,6 +1403,18 @@
     const notificationsRefreshBtn = document.getElementById('notifications-refresh');
     const teamsTestBtn = document.getElementById('teams-test-alert');
     const teamsBriefBtn = document.getElementById('teams-send-brief');
+    document.getElementById('overview-attention-page-size')?.addEventListener('change', () => {
+      setAttentionPage(1);
+      renderAttentionRows(ctx);
+    });
+    document.getElementById('overview-attention-page-prev')?.addEventListener('click', (e) => {
+      e.preventDefault();
+      moveAttentionPage(ctx, -1);
+    });
+    document.getElementById('overview-attention-page-next')?.addEventListener('click', (e) => {
+      e.preventDefault();
+      moveAttentionPage(ctx, 1);
+    });
     w.wireBusyClick(failedRunsRefreshBtn, 'Refreshing…', async () => { await ctx.loadFailedRuns(24, true); });
     w.wireBusyClick(notificationsRefreshBtn, 'Refreshing…', async () => { await loadNotifications(ctx, true); });
     w.wireBusyClick(teamsTestBtn, 'Sending…', async () => {

--- a/server/app/templates/index.html
+++ b/server/app/templates/index.html
@@ -557,6 +557,15 @@
         <div style="display:flex;align-items:center;justify-content:space-between;gap:0.5rem;flex-wrap:wrap;margin-top:0.75rem;">
           <span id="hosts-visible-counter" role="status" aria-live="polite" style="color:var(--muted-2);font-size:0.9rem;">0 / 0 hosts shown</span>
           <div style="display:flex;align-items:center;gap:0.5rem;flex-wrap:wrap;">
+            <label style="color:var(--muted-2);font-size:0.9rem;">Rows</label>
+            <select id="hosts-page-size" class="host-search" style="width:auto;padding:0.35rem 0.5rem;">
+              <option value="10" selected>10</option>
+              <option value="50">50</option>
+              <option value="all">All</option>
+            </select>
+            <button class="btn" id="hosts-page-prev" type="button">Prev</button>
+            <span id="hosts-page-label" style="color:var(--muted-2);font-size:0.9rem;">Page 1 / 1</span>
+            <button class="btn" id="hosts-page-next" type="button">Next</button>
             <label style="color:var(--muted-2);font-size:0.9rem;">Sort</label>
           <select id="hosts-sort" class="host-search" style="width:auto;padding:0.35rem 0.5rem;">
             <option value="hostname" selected>Host</option>
@@ -3725,10 +3734,34 @@
       });
       document.getElementById('hosts-sort')?.addEventListener('change', loadHostsTable);
       document.getElementById('hosts-order')?.addEventListener('change', loadHostsTable);
+      document.getElementById('hosts-page-size')?.addEventListener('change', () => {
+        const mod = window.phase3Overview;
+        if (mod && typeof mod.setHostsTablePage === 'function') mod.setHostsTablePage(1);
+        if (mod && typeof mod.applyHostsTableFilters === 'function') mod.applyHostsTableFilters(getOverviewCtx());
+      });
+      document.getElementById('hosts-page-prev')?.addEventListener('click', (e) => {
+        e.preventDefault();
+        const mod = window.phase3Overview;
+        if (mod && typeof mod.moveHostsTablePage === 'function') mod.moveHostsTablePage(getOverviewCtx(), -1);
+      });
+      document.getElementById('hosts-page-next')?.addEventListener('click', (e) => {
+        e.preventDefault();
+        const mod = window.phase3Overview;
+        if (mod && typeof mod.moveHostsTablePage === 'function') mod.moveHostsTablePage(getOverviewCtx(), 1);
+      });
 
       document.getElementById('hosts-select-all')?.addEventListener('change', (e) => {
         const checked = !!e.target.checked;
-        document.querySelectorAll('.hosts-row-select').forEach(cb => { cb.checked = checked; });
+        const selected = selectedAgentIds instanceof Set ? selectedAgentIds : new Set();
+        document.querySelectorAll('.hosts-row-select').forEach(cb => {
+          cb.checked = checked;
+          const aid = String(cb.getAttribute('data-agent-id') || '').trim();
+          if (!aid) return;
+          if (checked) selected.add(aid);
+          else selected.delete(aid);
+        });
+        selectedAgentIds = selected;
+        updateUpgradeControlsFn();
       });
 
       async function confirmBlastRadius(agentIds, actionLabel, threshold = 5) {

--- a/server/app/templates/index.html
+++ b/server/app/templates/index.html
@@ -256,6 +256,20 @@
               <div class="admin-card" style="margin:0;height:100%;">
                 <div class="admin-card-title">Host Inventory</div>
                 <div class="admin-card-body">
+                  <div style="display:flex;align-items:center;justify-content:space-between;gap:0.5rem;flex-wrap:wrap;margin-bottom:0.5rem;">
+                    <span id="overview-attention-counter" role="status" aria-live="polite" style="color:var(--muted-2);font-size:0.85rem;">0 / 0 hosts shown</span>
+                    <div style="display:flex;align-items:center;gap:0.45rem;flex-wrap:wrap;">
+                      <label style="color:var(--muted-2);font-size:0.85rem;">Rows</label>
+                      <select id="overview-attention-page-size" class="host-search" style="width:auto;padding:0.3rem 0.45rem;">
+                        <option value="10" selected>10</option>
+                        <option value="50">50</option>
+                        <option value="all">All</option>
+                      </select>
+                      <button class="btn" id="overview-attention-page-prev" type="button" style="padding:0.2rem 0.45rem;">Prev</button>
+                      <span id="overview-attention-page-label" style="color:var(--muted-2);font-size:0.85rem;">Page 1 / 1</span>
+                      <button class="btn" id="overview-attention-page-next" type="button" style="padding:0.2rem 0.45rem;">Next</button>
+                    </div>
+                  </div>
                   <div id="overview-attention" class="status-muted">Loading…</div>
                 </div>
               </div>

--- a/server/tests/frontend/dashboard-attention-pagination.test.js
+++ b/server/tests/frontend/dashboard-attention-pagination.test.js
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+describe('dashboard attention pagination UI', () => {
+  const root = path.resolve(path.dirname(new URL(import.meta.url).pathname), '../../..');
+  const htmlPath = path.join(root, 'server/app/templates/index.html');
+  const overviewPath = path.join(root, 'server/app/templates/fleet-phase3-overview.js');
+  const html = fs.readFileSync(htmlPath, 'utf8');
+  const overview = fs.readFileSync(overviewPath, 'utf8');
+
+  it('defaults Dashboard Host Inventory issues to 10 rows with 50 and All options', () => {
+    expect(html).toContain('id="overview-attention-page-size"');
+    expect(html).toContain('<option value="10" selected>10</option>');
+    expect(html).toContain('<option value="50">50</option>');
+    expect(html).toContain('<option value="all">All</option>');
+    expect(html).toContain('id="overview-attention-page-prev"');
+    expect(html).toContain('id="overview-attention-page-next"');
+  });
+
+  it('renders only the current Dashboard attention page', () => {
+    expect(overview).toContain("const raw = String(document.getElementById('overview-attention-page-size')?.value || '10')");
+    expect(overview).toContain('return n === 50 ? 50 : 10;');
+    expect(overview).toContain('rows.slice((attentionPage - 1) * pageSize, attentionPage * pageSize)');
+    expect(overview).toContain('for (const it of pageRows)');
+    expect(overview).toContain("document.getElementById('overview-attention-page-next')?.addEventListener('click'");
+  });
+});

--- a/server/tests/frontend/hosts-pagination.test.js
+++ b/server/tests/frontend/hosts-pagination.test.js
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+describe('hosts table pagination UI', () => {
+  const root = path.resolve(path.dirname(new URL(import.meta.url).pathname), '../../..');
+  const htmlPath = path.join(root, 'server/app/templates/index.html');
+  const overviewPath = path.join(root, 'server/app/templates/fleet-phase3-overview.js');
+  const html = fs.readFileSync(htmlPath, 'utf8');
+  const overview = fs.readFileSync(overviewPath, 'utf8');
+
+  it('defaults Host Inventory to 10 rows with 50 and All options', () => {
+    expect(html).toContain('id="hosts-page-size"');
+    expect(html).toContain('<option value="10" selected>10</option>');
+    expect(html).toContain('<option value="50">50</option>');
+    expect(html).toContain('<option value="all">All</option>');
+    expect(html).toContain('id="hosts-page-prev"');
+    expect(html).toContain('id="hosts-page-next"');
+  });
+
+  it('renders only the current host page and tracks visible host ids', () => {
+    expect(overview).toContain("const raw = String(document.getElementById('hosts-page-size')?.value || '10')");
+    expect(overview).toContain('return n === 50 ? 50 : 10;');
+    expect(overview).toContain('filteredItems.slice((hostsTablePage - 1) * pageSize, hostsTablePage * pageSize)');
+    expect(overview).toContain('for (const it of pageItems)');
+    expect(overview).toContain('ctx.setLastRenderedAgentIds(pageItems.map');
+  });
+});


### PR DESCRIPTION
## Summary
- Add Hosts-style row controls to the Dashboard Host Inventory attention list
- Page Dashboard attention rows locally with default 10, 50, and All options
- Keep existing issue-link navigation/remediation behavior intact

## Tests
- npm run test:frontend -- server/tests/frontend/hosts-pagination.test.js server/tests/frontend/dashboard-attention-pagination.test.js