### PR TITLE
Require agent HMAC by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ Keep `.env` files private.
   deployed; it should only be enabled temporarily for old-agent compatibility.
 - Keep `AGENT_SHARED_TOKEN_ALLOW_REBIND=false` after agents check in with
   persisted per-agent tokens.
-- Updated agents send HMAC request signatures. Set `AGENT_HMAC_REQUIRED=true`
-  after all managed agents have this version.
+- Updated agents send HMAC request signatures. Keep `AGENT_HMAC_REQUIRED=true`
+  except during temporary old-agent migration.
 - MFA is enabled for privileged users by default.
 - The browser terminal feature is powerful; enable it only where needed.

--- a/deploy/docker/docker-compose.yml
+++ b/deploy/docker/docker-compose.yml
@@ -53,8 +53,8 @@ services:
       AGENT_SHARED_TOKEN_ALLOW_RUNTIME: ${AGENT_SHARED_TOKEN_ALLOW_RUNTIME:-false}
       # Temporary migration path for agents that need to persist their first per-agent token.
       AGENT_SHARED_TOKEN_ALLOW_REBIND: ${AGENT_SHARED_TOKEN_ALLOW_REBIND:-false}
-      # Optional stronger per-agent request signing. Enable after all agents have this version.
-      AGENT_HMAC_REQUIRED: ${AGENT_HMAC_REQUIRED:-false}
+      # Require per-agent request signing. Set false only during old-agent migration.
+      AGENT_HMAC_REQUIRED: ${AGENT_HMAC_REQUIRED:-true}
       AGENT_HMAC_MAX_SKEW_SECONDS: ${AGENT_HMAC_MAX_SKEW_SECONDS:-300}
       # Keep false unless intentionally running loopback-only tests without an agent token.
       ALLOW_INSECURE_NO_AGENT_TOKEN: ${ALLOW_INSECURE_NO_AGENT_TOKEN:-false}

--- a/deploy/docker/env.example
+++ b/deploy/docker/env.example
@@ -47,8 +47,8 @@ AGENT_SHARED_TOKEN=change-me-agent-token
 AGENT_SHARED_TOKEN_ALLOW_RUNTIME=false
 # Temporary migration path for agents that need to persist their first per-agent token.
 AGENT_SHARED_TOKEN_ALLOW_REBIND=false
-# Optional stronger per-agent request signing. Enable after all agents have this version.
-AGENT_HMAC_REQUIRED=false
+# Require per-agent request signing. Set false only during old-agent migration.
+AGENT_HMAC_REQUIRED=true
 AGENT_HMAC_MAX_SKEW_SECONDS=300
 # Keep false unless intentionally running loopback-only tests without an agent token.
 ALLOW_INSECURE_NO_AGENT_TOKEN=false

--- a/docs/security-baseline.md
+++ b/docs/security-baseline.md
@@ -70,8 +70,9 @@ an admin can reset that host for bootstrap registration or rotate a one-time
 replacement token through the host agent-token admin API.
 
 Updated agents send HMAC request signatures derived from their per-agent token.
-Set `AGENT_HMAC_REQUIRED=true` after all agents have this version to reject
-unsigned per-agent requests.
+`AGENT_HMAC_REQUIRED=true` is the default for new deployments and rejects
+unsigned per-agent requests. Set it to `false` only as a temporary migration
+escape hatch for old agents.
 
 ## 6) Auditability
 - Audit logging is enabled for auth, MFA, user lifecycle, and package actions.

--- a/install.sh
+++ b/install.sh
@@ -344,7 +344,7 @@ main() {
   set_env_value "$docker_env" "AGENT_SHARED_TOKEN" "$agent_token"
   set_env_value "$docker_env" "AGENT_SHARED_TOKEN_ALLOW_RUNTIME" "false"
   set_env_value "$docker_env" "AGENT_SHARED_TOKEN_ALLOW_REBIND" "false"
-  set_env_value "$docker_env" "AGENT_HMAC_REQUIRED" "false"
+  set_env_value "$docker_env" "AGENT_HMAC_REQUIRED" "true"
   set_env_value "$docker_env" "AGENT_HMAC_MAX_SKEW_SECONDS" "300"
   set_env_value "$docker_env" "MFA_ENCRYPTION_KEY" "$mfa_key"
   set_env_value "$docker_env" "UI_COOKIE_SECURE" "$ui_cookie_secure"

--- a/server/app/config.py
+++ b/server/app/config.py
@@ -31,9 +31,10 @@ class Settings(BaseSettings):
     # Temporary migration path for agents upgraded after per-agent tokens were introduced
     # but before their runtime token was persisted locally.
     agent_shared_token_allow_rebind: bool = False
-    # Optional stronger request authentication for per-agent tokens. Updated agents
-    # send HMAC signatures automatically; set true after rollout to require them.
-    agent_hmac_required: bool = False
+    # Require request authentication for per-agent tokens. Updated agents send
+    # HMAC signatures automatically; set false only as a temporary old-agent
+    # migration escape hatch.
+    agent_hmac_required: bool = True
     agent_hmac_max_skew_seconds: int = 300
     allow_insecure_no_agent_token: bool = False
 

--- a/server/tests/test_agent_auth_hardening.py
+++ b/server/tests/test_agent_auth_hardening.py
@@ -21,6 +21,7 @@ def _boot_app(
     token: str = '',
     allow_shared_runtime: bool = False,
     allow_shared_rebind: bool = True,
+    hmac_required: bool = False,
 ):
     monkeypatch.setenv('DATABASE_URL', 'sqlite+pysqlite:///:memory:')
     monkeypatch.setenv('SERVER_BIND_HOST', '127.0.0.1')
@@ -30,6 +31,7 @@ def _boot_app(
     monkeypatch.setenv('AGENT_SHARED_TOKEN', token)
     monkeypatch.setenv('AGENT_SHARED_TOKEN_ALLOW_RUNTIME', 'true' if allow_shared_runtime else 'false')
     monkeypatch.setenv('AGENT_SHARED_TOKEN_ALLOW_REBIND', 'true' if allow_shared_rebind else 'false')
+    monkeypatch.setenv('AGENT_HMAC_REQUIRED', 'true' if hmac_required else 'false')
     monkeypatch.setenv('DB_AUTO_CREATE_TABLES', 'true')
     monkeypatch.setenv('DB_REQUIRE_MIGRATIONS_UP_TO_DATE', 'false')
     monkeypatch.setenv('MFA_REQUIRE_FOR_PRIVILEGED', 'false')
@@ -193,8 +195,7 @@ def test_per_agent_token_requires_agent_id_header(monkeypatch):
 
 
 def test_per_agent_hmac_can_be_required(monkeypatch):
-    monkeypatch.setenv('AGENT_HMAC_REQUIRED', 'true')
-    app = _boot_app(monkeypatch, insecure_no_token=False, token='shared-secret-123')
+    app = _boot_app(monkeypatch, insecure_no_token=False, token='shared-secret-123', hmac_required=True)
 
     with TestClient(app, client=('192.168.100.50', 12345)) as client:
         agent_token = _register_agent(client, 'srv-hmac')

--- a/server/tests/test_startup_guardrails.py
+++ b/server/tests/test_startup_guardrails.py
@@ -85,3 +85,16 @@ def test_docker_compose_defaults_bind_server_to_network_interface():
 
     assert "SERVER_BIND_HOST: ${SERVER_BIND_HOST:-0.0.0.0}" in compose
     assert "--host ${SERVER_BIND_HOST:-0.0.0.0}" in dockerfile
+
+
+def test_new_deployments_require_agent_hmac_by_default():
+    root = Path(__file__).resolve().parents[2]
+    config = (root / "server/app/config.py").read_text(encoding="utf-8")
+    compose = (root / "deploy/docker/docker-compose.yml").read_text(encoding="utf-8")
+    env_example = (root / "deploy/docker/env.example").read_text(encoding="utf-8")
+    install_script = (root / "install.sh").read_text(encoding="utf-8")
+
+    assert "agent_hmac_required: bool = True" in config
+    assert "AGENT_HMAC_REQUIRED: ${AGENT_HMAC_REQUIRED:-true}" in compose
+    assert "AGENT_HMAC_REQUIRED=true" in env_example
+    assert 'set_env_value "$docker_env" "AGENT_HMAC_REQUIRED" "true"' in install_script


### PR DESCRIPTION
## Summary
- Require per-agent HMAC request signatures by default in server config
- Set Docker Compose, env example, and installer-generated deployments to AGENT_HMAC_REQUIRED=true
- Update security docs to describe false as a temporary old-agent migration escape hatch

## Tests
- .venv/bin/python -m pytest server/tests/test_agent_auth_hardening.py server/tests/test_startup_guardrails.py
- bash -n install.sh script.sh
- git diff --check