### PR TITLE
Audit terminal session access

### DIFF
--- a/server/app/routers/terminal_ws.py
+++ b/server/app/routers/terminal_ws.py
@@ -12,6 +12,7 @@ from ..config import settings
 from ..db import SessionLocal
 from ..deps import SESSION_COOKIE, sha256_hex
 from ..models import AppSession, AppUser, Host
+from ..services.audit import log_event
 from ..services.hosts import resolve_host_target
 from ..services.user_scopes import is_host_visible_to_user
 from ..terminal_pipe import raw_pipe
@@ -47,6 +48,53 @@ def _websocket_origin_allowed(headers) -> bool:
     return parsed_origin.netloc.lower() in allowed_hosts
 
 
+def _terminal_ws_meta(ws: WebSocket, *, role: str | None = None, term_access: str | None = None, reason: str | None = None) -> dict:
+    meta = {
+        "client_host": str(getattr(getattr(ws, "client", None), "host", "") or ""),
+        "origin": str(ws.headers.get("origin") or ""),
+        "host": str(ws.headers.get("host") or ""),
+    }
+    if role:
+        meta["role"] = role
+    if term_access:
+        meta["terminal_access"] = term_access
+    if reason:
+        meta["reason"] = reason
+    return meta
+
+
+def _audit_terminal_event(
+    db,
+    *,
+    action: str,
+    user: AppUser | None,
+    host: Host | None,
+    agent_id: str,
+    ws: WebSocket,
+    role: str | None = None,
+    term_access: str | None = None,
+    reason: str | None = None,
+    connect_target: str | None = None,
+) -> None:
+    meta = _terminal_ws_meta(ws, role=role, term_access=term_access, reason=reason)
+    if connect_target:
+        meta["connect_target"] = connect_target
+    log_event(
+        db,
+        action=action,
+        actor=user,
+        request=None,
+        target_type="host",
+        target_id=str(getattr(host, "agent_id", None) or agent_id or ""),
+        target_name=str(getattr(host, "hostname", None) or agent_id or ""),
+        meta=meta,
+    )
+    try:
+        db.commit()
+    except Exception:
+        db.rollback()
+
+
 @router.websocket("/terminal/{agent_id}")
 async def ws_terminal(ws: WebSocket, agent_id: str) -> None:
     if not _websocket_origin_allowed(ws.headers):
@@ -56,6 +104,11 @@ async def ws_terminal(ws: WebSocket, agent_id: str) -> None:
     await ws.accept()
 
     db = SessionLocal()
+    audit_user: AppUser | None = None
+    audit_host: Host | None = None
+    audit_role: str | None = None
+    audit_term_access: str | None = None
+    audit_connect_to: str | None = None
     try:
         token = getattr(ws, "cookies", {}).get(SESSION_COOKIE)
         if not token:
@@ -78,24 +131,65 @@ async def ws_terminal(ws: WebSocket, agent_id: str) -> None:
         if not user:
             await ws.close(code=4401, reason="Not authenticated")
             return
+        audit_user = user
 
         host = db.execute(select(Host).where(Host.agent_id == agent_id)).scalar_one_or_none()
         if not host:
+            _audit_terminal_event(
+                db,
+                action="terminal.session.denied",
+                user=user,
+                host=None,
+                agent_id=agent_id,
+                ws=ws,
+                reason="host_not_found",
+            )
             await ws.close(code=1008, reason="Host not found")
             return
+        audit_host = host
         if not is_host_visible_to_user(db, user, host):
+            _audit_terminal_event(
+                db,
+                action="terminal.session.denied",
+                user=user,
+                host=host,
+                agent_id=agent_id,
+                ws=ws,
+                reason="host_out_of_scope",
+            )
             await ws.close(code=4403, reason="Host out of scope")
             return
 
         # Enforce MFA for privileged roles before allowing terminal.
         role = (getattr(user, "role", "operator") or "operator").lower()
+        audit_role = role
         require_mfa = bool(getattr(settings, "mfa_require_for_privileged", True)) and role in ("admin", "operator")
         if require_mfa:
             if not bool(getattr(user, "mfa_enabled", False)):
+                _audit_terminal_event(
+                    db,
+                    action="terminal.session.denied",
+                    user=user,
+                    host=host,
+                    agent_id=agent_id,
+                    ws=ws,
+                    role=role,
+                    reason="mfa_enrollment_required",
+                )
                 await ws.send_text("\r\n[ERROR] MFA enrollment required before using terminal.\r\n")
                 await ws.close(code=4403, reason="MFA enrollment required")
                 return
             if not bool(getattr(sess, "mfa_verified_at", None)):
+                _audit_terminal_event(
+                    db,
+                    action="terminal.session.denied",
+                    user=user,
+                    host=host,
+                    agent_id=agent_id,
+                    ws=ws,
+                    role=role,
+                    reason="mfa_verification_required",
+                )
                 await ws.send_text("\r\n[ERROR] MFA verification required before using terminal.\r\n")
                 await ws.close(code=4403, reason="MFA verification required")
                 return
@@ -112,6 +206,7 @@ async def ws_terminal(ws: WebSocket, agent_id: str) -> None:
 
         host_labels = (host.labels or {}) if hasattr(host, "labels") else {}
         term_access = str(host_labels.get("terminal_access") or "all").strip().lower()
+        audit_term_access = term_access
 
         allow_input = True
 
@@ -121,21 +216,66 @@ async def ws_terminal(ws: WebSocket, agent_id: str) -> None:
             # Operators can use terminal by default, like a VMware console.
             # Host label terminal_access can restrict it.
             if term_access in ("none", "disabled"):
+                _audit_terminal_event(
+                    db,
+                    action="terminal.session.denied",
+                    user=user,
+                    host=host,
+                    agent_id=agent_id,
+                    ws=ws,
+                    role=role,
+                    term_access=term_access,
+                    reason="terminal_access_none",
+                )
                 await ws.send_text("\r\n[ERROR] Terminal access denied for this host (terminal_access=none).\r\n")
                 await ws.close(code=4403, reason="Terminal not allowed")
                 return
             if term_access == "admin":
+                _audit_terminal_event(
+                    db,
+                    action="terminal.session.denied",
+                    user=user,
+                    host=host,
+                    agent_id=agent_id,
+                    ws=ws,
+                    role=role,
+                    term_access=term_access,
+                    reason="terminal_access_admin",
+                )
                 await ws.send_text("\r\n[ERROR] Terminal access denied for this host (terminal_access=admin).\r\n")
                 await ws.close(code=4403, reason="Terminal not allowed")
                 return
             allow_input = True
         else:
+            _audit_terminal_event(
+                db,
+                action="terminal.session.denied",
+                user=user,
+                host=host,
+                agent_id=agent_id,
+                ws=ws,
+                role=role,
+                term_access=term_access,
+                reason="role_not_allowed",
+            )
             await ws.send_text("\r\n[ERROR] Terminal access is restricted.\r\n")
             await ws.close(code=4403, reason="Terminal not allowed")
             return
 
         connect_to = resolve_host_target(host)
+        audit_connect_to = connect_to
         if not connect_to:
+            _audit_terminal_event(
+                db,
+                action="terminal.session.denied",
+                user=user,
+                host=host,
+                agent_id=agent_id,
+                ws=ws,
+                role=role,
+                term_access=term_access,
+                reason="no_reachable_target",
+            )
             await ws.close(code=1008, reason="Host has no reachable target")
             return
 
@@ -145,14 +285,59 @@ async def ws_terminal(ws: WebSocket, agent_id: str) -> None:
 
         term_token = getattr(settings, "agent_terminal_token", None)
         if not term_token:
+            _audit_terminal_event(
+                db,
+                action="terminal.session.denied",
+                user=user,
+                host=host,
+                agent_id=agent_id,
+                ws=ws,
+                role=role,
+                term_access=term_access,
+                reason="terminal_disabled",
+            )
             await ws.send_text("\r\n[ERROR] Terminal is disabled on server (AGENT_TERMINAL_TOKEN not set).\r\n")
             await ws.close(code=1008, reason="Terminal disabled")
             return
 
         logger.info("Connecting to agent terminal: agent_id=%s url=%s", agent_id, agent_url)
+        _audit_terminal_event(
+            db,
+            action="terminal.session.opened",
+            user=user,
+            host=host,
+            agent_id=agent_id,
+            ws=ws,
+            role=role,
+            term_access=term_access,
+            connect_target=connect_to,
+        )
         await raw_pipe(ws, agent_url, headers={"X-Fleet-Terminal-Token": term_token}, allow_input=allow_input)
+        _audit_terminal_event(
+            db,
+            action="terminal.session.closed",
+            user=user,
+            host=host,
+            agent_id=agent_id,
+            ws=ws,
+            role=role,
+            term_access=term_access,
+            connect_target=connect_to,
+        )
 
     except Exception as e:
+        _audit_terminal_event(
+            db,
+            action="terminal.session.error",
+            user=audit_user,
+            host=audit_host,
+            agent_id=agent_id,
+            ws=ws,
+            role=audit_role,
+            term_access=audit_term_access,
+            reason=type(e).__name__,
+            connect_target=audit_connect_to,
+        )
         logger.error("Error in ws_terminal: agent_id=%s err=%s", agent_id, e, exc_info=True)
         with suppress(Exception):
             await ws.close(code=1011, reason=f"Server error: {e}")

--- a/server/tests/test_terminal_audit.py
+++ b/server/tests/test_terminal_audit.py
@@ -1,0 +1,150 @@
+import importlib
+import secrets
+import sys
+from datetime import datetime, timedelta, timezone
+
+from fastapi.testclient import TestClient
+
+
+def _reload_app_modules():
+    for name in list(sys.modules.keys()):
+        if name == "app" or name.startswith("app."):
+            sys.modules.pop(name, None)
+
+
+def _boot_app(monkeypatch):
+    monkeypatch.setenv("DATABASE_URL", "sqlite+pysqlite:///:memory:")
+    monkeypatch.setenv("SERVER_BIND_HOST", "127.0.0.1")
+    monkeypatch.setenv("BOOTSTRAP_USERNAME", "admin")
+    monkeypatch.setenv("BOOTSTRAP_PASSWORD", "admin-password-123")
+    monkeypatch.setenv("UI_COOKIE_SECURE", "false")
+    monkeypatch.setenv("ALLOW_INSECURE_NO_AGENT_TOKEN", "true")
+    monkeypatch.setenv("AGENT_SHARED_TOKEN", "")
+    monkeypatch.setenv("AGENT_TERMINAL_TOKEN", "real-terminal-token")
+    monkeypatch.setenv("DB_AUTO_CREATE_TABLES", "true")
+    monkeypatch.setenv("DB_REQUIRE_MIGRATIONS_UP_TO_DATE", "false")
+    monkeypatch.setenv("MFA_REQUIRE_FOR_PRIVILEGED", "false")
+    _reload_app_modules()
+    app_factory = importlib.import_module("app.app_factory")
+    return app_factory.create_app()
+
+
+def _create_session(username: str, role: str, labels: dict | None = None) -> str:
+    db_mod = importlib.import_module("app.db")
+    deps = importlib.import_module("app.deps")
+    models = importlib.import_module("app.models")
+
+    token = secrets.token_urlsafe(24)
+    host_labels = {"owner": username}
+    host_labels.update(labels or {})
+    with db_mod.SessionLocal() as db:
+        user = models.AppUser(username=username, password_hash="unused", role=role, is_active=True)
+        db.add(user)
+        db.flush()
+        db.add(
+            models.AppSession(
+                user_id=user.id,
+                token_sha256=deps.sha256_hex(token),
+                expires_at=datetime.now(timezone.utc) + timedelta(hours=1),
+            )
+        )
+        db.add(
+            models.Host(
+                agent_id="srv-terminal",
+                hostname="srv-terminal",
+                ip_address="192.0.2.55",
+                os_id="ubuntu",
+                os_version="24.04",
+                kernel="test",
+                labels=host_labels,
+                last_seen=datetime.now(timezone.utc),
+            )
+        )
+        db.commit()
+    return token
+
+
+def _audit_events(action: str):
+    db_mod = importlib.import_module("app.db")
+    models = importlib.import_module("app.models")
+    with db_mod.SessionLocal() as db:
+        return db.query(models.AuditEvent).filter_by(action=action).order_by(models.AuditEvent.created_at.asc()).all()
+
+
+def test_terminal_session_open_and_close_are_audited(monkeypatch):
+    app = _boot_app(monkeypatch)
+    terminal_ws = importlib.import_module("app.routers.terminal_ws")
+
+    async def fake_raw_pipe(ws, agent_url, headers=None, allow_input=True):
+        assert agent_url == "ws://192.0.2.55:18080/terminal/ws"
+        assert headers == {"X-Fleet-Terminal-Token": "real-terminal-token"}
+        assert allow_input is True
+        await ws.send_text("terminal-ok")
+
+    monkeypatch.setattr(terminal_ws, "raw_pipe", fake_raw_pipe)
+
+    with TestClient(app) as client:
+        token = _create_session("operator1", "operator")
+        client.cookies.set("fleet_session", token)
+        with client.websocket_connect("/ws/terminal/srv-terminal") as ws:
+            assert ws.receive_text() == "terminal-ok"
+
+    opened = _audit_events("terminal.session.opened")
+    closed = _audit_events("terminal.session.closed")
+    assert len(opened) == 1
+    assert len(closed) == 1
+    assert opened[0].actor_username == "operator1"
+    assert opened[0].target_id == "srv-terminal"
+    assert opened[0].meta["role"] == "operator"
+    assert opened[0].meta["terminal_access"] == "all"
+    assert opened[0].meta["connect_target"] == "192.0.2.55"
+    assert "real-terminal-token" not in str(opened[0].meta)
+
+
+def test_terminal_policy_denial_is_audited(monkeypatch):
+    app = _boot_app(monkeypatch)
+
+    with TestClient(app) as client:
+        token = _create_session("operator2", "operator", labels={"terminal_access": "admin"})
+        client.cookies.set("fleet_session", token)
+        try:
+            with client.websocket_connect("/ws/terminal/srv-terminal") as ws:
+                ws.receive_text()
+        except Exception:
+            pass
+
+    denied = _audit_events("terminal.session.denied")
+    assert len(denied) == 1
+    assert denied[0].actor_username == "operator2"
+    assert denied[0].target_id == "srv-terminal"
+    assert denied[0].meta["role"] == "operator"
+    assert denied[0].meta["terminal_access"] == "admin"
+    assert denied[0].meta["reason"] == "terminal_access_admin"
+
+
+def test_terminal_pipe_error_is_audited_without_secrets(monkeypatch):
+    app = _boot_app(monkeypatch)
+    terminal_ws = importlib.import_module("app.routers.terminal_ws")
+
+    async def failing_raw_pipe(ws, agent_url, headers=None, allow_input=True):
+        raise RuntimeError("agent terminal exploded")
+
+    monkeypatch.setattr(terminal_ws, "raw_pipe", failing_raw_pipe)
+
+    with TestClient(app) as client:
+        token = _create_session("operator3", "operator")
+        client.cookies.set("fleet_session", token)
+        try:
+            with client.websocket_connect("/ws/terminal/srv-terminal") as ws:
+                ws.receive_text()
+        except Exception:
+            pass
+
+    errors = _audit_events("terminal.session.error")
+    assert len(errors) == 1
+    assert errors[0].actor_username == "operator3"
+    assert errors[0].target_id == "srv-terminal"
+    assert errors[0].meta["role"] == "operator"
+    assert errors[0].meta["reason"] == "RuntimeError"
+    assert errors[0].meta["connect_target"] == "192.0.2.55"
+    assert "real-terminal-token" not in str(errors[0].meta)


### PR DESCRIPTION
## Summary
- Add audit events for terminal session denied/opened/closed/error paths
- Include actor, host, role, terminal_access policy, client metadata, and deny/error reason without logging terminal tokens
- Add websocket tests covering successful terminal audit, policy denial audit, and terminal pipe error audit

## Tests
- .venv/bin/python -m pytest server/tests/test_terminal_audit.py server/tests/test_terminal_pipe_transport.py
- git diff --check