### PR TITLE
Harden default content security policy

### DIFF
--- a/docs/security-baseline.md
+++ b/docs/security-baseline.md
@@ -88,3 +88,9 @@ break-glass operation.
 - Restrict UI access to VPN/LAN.
 - Restrict agent-to-server access to expected networks.
 - Consider firewall rules and rate limiting at the proxy.
+
+## 9) Browser security headers
+The default `Content-Security-Policy` uses per-response script nonces, blocks
+inline script attributes, disallows framing, blocks plugins/workers by default,
+and restricts form targets to the app origin. Inline styles remain allowed
+because the current server-rendered UI uses inline style attributes heavily.

--- a/server/app/app_factory.py
+++ b/server/app/app_factory.py
@@ -120,6 +120,23 @@ def _enforce_non_local_security_guardrails() -> None:
         raise RuntimeError("Startup blocked by production guardrails: " + "; ".join(failures))
 
 
+def _default_content_security_policy(nonce: str) -> str:
+    return (
+        "default-src 'self'; "
+        "script-src 'self' 'nonce-" + str(nonce) + "'; "
+        "script-src-attr 'none'; "
+        "style-src 'self' 'unsafe-inline'; "
+        "img-src 'self' data:; "
+        "font-src 'self' data:; "
+        "connect-src 'self' ws: wss:; "
+        "form-action 'self'; "
+        "frame-src 'none'; "
+        "manifest-src 'self'; "
+        "worker-src 'none'; "
+        "object-src 'none'; base-uri 'self'; frame-ancestors 'none'"
+    )
+
+
 def _startup() -> None:
     from .config import settings
 
@@ -546,16 +563,7 @@ def create_app() -> FastAPI:
             resp.headers.setdefault("Content-Security-Policy", str(csp))
         else:
             nonce = getattr(getattr(request, "state", None), "csp_nonce", "")
-            resp.headers.setdefault(
-                "Content-Security-Policy",
-                "default-src 'self'; "
-                "script-src 'self' 'nonce-" + str(nonce) + "'; "
-                "style-src 'self' 'unsafe-inline'; "
-                "img-src 'self' data:; "
-                "font-src 'self' data:; "
-                "connect-src 'self' ws: wss:; "
-                "object-src 'none'; base-uri 'self'; frame-ancestors 'none'",
-            )
+            resp.headers.setdefault("Content-Security-Policy", _default_content_security_policy(str(nonce)))
 
         return resp
 

--- a/server/tests/test_security_headers.py
+++ b/server/tests/test_security_headers.py
@@ -1,0 +1,56 @@
+import importlib
+import sys
+
+from fastapi.testclient import TestClient
+
+
+def _reload_app_modules():
+    for name in list(sys.modules.keys()):
+        if name == "app" or name.startswith("app."):
+            sys.modules.pop(name, None)
+
+
+def _boot_app(monkeypatch):
+    monkeypatch.setenv("DATABASE_URL", "sqlite+pysqlite:///:memory:")
+    monkeypatch.setenv("SERVER_BIND_HOST", "127.0.0.1")
+    monkeypatch.setenv("BOOTSTRAP_USERNAME", "admin")
+    monkeypatch.setenv("BOOTSTRAP_PASSWORD", "admin-password-123")
+    monkeypatch.setenv("UI_COOKIE_SECURE", "false")
+    monkeypatch.setenv("ALLOW_INSECURE_NO_AGENT_TOKEN", "true")
+    monkeypatch.setenv("AGENT_SHARED_TOKEN", "")
+    monkeypatch.setenv("DB_AUTO_CREATE_TABLES", "true")
+    monkeypatch.setenv("DB_REQUIRE_MIGRATIONS_UP_TO_DATE", "false")
+    monkeypatch.setenv("MFA_REQUIRE_FOR_PRIVILEGED", "false")
+    _reload_app_modules()
+    app_factory = importlib.import_module("app.app_factory")
+    return app_factory.create_app()
+
+
+def test_default_csp_blocks_script_attrs_and_framing():
+    app_factory = importlib.import_module("app.app_factory")
+    csp = app_factory._default_content_security_policy("test-nonce")
+
+    assert "script-src 'self' 'nonce-test-nonce'" in csp
+    assert "script-src-attr 'none'" in csp
+    assert "form-action 'self'" in csp
+    assert "frame-src 'none'" in csp
+    assert "manifest-src 'self'" in csp
+    assert "worker-src 'none'" in csp
+    assert "object-src 'none'" in csp
+    assert "base-uri 'self'" in csp
+    assert "frame-ancestors 'none'" in csp
+
+
+def test_ui_response_gets_hardened_default_csp(monkeypatch):
+    app = _boot_app(monkeypatch)
+
+    with TestClient(app) as client:
+        response = client.get("/login")
+
+    assert response.status_code == 200
+    csp = response.headers.get("Content-Security-Policy", "")
+    assert "script-src 'self' 'nonce-" in csp
+    assert "script-src-attr 'none'" in csp
+    assert "form-action 'self'" in csp
+    assert "frame-src 'none'" in csp
+    assert "worker-src 'none'" in csp


### PR DESCRIPTION
## Summary
- Factor default CSP generation into a tested helper
- Add stricter default directives: script-src-attr 'none', form-action 'self', frame-src 'none', manifest-src 'self', worker-src 'none'
- Document the default CSP posture and why inline styles remain allowed for now

## Tests
- .venv/bin/python -m pytest server/tests/test_security_headers.py server/tests/test_ui_version_footer.py server/tests/test_startup_guardrails.py
- git diff --check