### PR TITLE
Require generated Postgres deploy secret

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,8 @@ Keep `.env` files private.
 - Use HTTPS if exposing the UI outside a trusted LAN.
 - Keep `AGENT_SHARED_TOKEN`, `AGENT_TERMINAL_TOKEN`, and
   `MFA_ENCRYPTION_KEY` secret.
+- Use a generated `POSTGRES_PASSWORD`; new Docker deployments no longer fall
+  back to the old `fleet/fleet` database password.
 - Keep `AGENT_SHARED_TOKEN_ALLOW_RUNTIME=false` once updated agents are
   deployed; it should only be enabled temporarily for old-agent compatibility.
 - Keep `AGENT_SHARED_TOKEN_ALLOW_REBIND=false` after agents check in with

--- a/deploy/docker/docker-compose.yml
+++ b/deploy/docker/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     environment:
       POSTGRES_DB: fleet
       POSTGRES_USER: fleet
-      POSTGRES_PASSWORD: fleet
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?set POSTGRES_PASSWORD in deploy/docker/.env}
     # Do not publish Postgres by default; keep it internal to the compose network.
     # If you need local DB access for debugging, add a compose override with:
     #   ports:
@@ -23,7 +23,7 @@ services:
       - .env
     environment:
       # Defaults; can be overridden in deploy/docker/.env
-      DATABASE_URL: ${DATABASE_URL:-postgresql+psycopg://fleet:fleet@db:5432/fleet}
+      DATABASE_URL: ${DATABASE_URL:-postgresql+psycopg://fleet:${POSTGRES_PASSWORD:?set POSTGRES_PASSWORD in deploy/docker/.env}@db:5432/fleet}
       ANSIBLE_DIR: /ansible
       ANSIBLE_INVENTORY: /ansible/inventory.yml
       ANSIBLE_LOG_DIR: /ansible_logs

--- a/deploy/docker/env.example
+++ b/deploy/docker/env.example
@@ -68,7 +68,8 @@ AGENT_TERMINAL_SCHEME=ws
 #         - "127.0.0.1:5432:5432"
 
 # Database (optional override)
-# DATABASE_URL=postgresql+psycopg://fleet:fleet@db:5432/fleet
+POSTGRES_PASSWORD=change-me-postgres-password
+# DATABASE_URL=postgresql+psycopg://fleet:${POSTGRES_PASSWORD}@db:5432/fleet
 
 # Teams alerts (optional)
 # Create an Incoming Webhook in Teams channel and paste URL here.

--- a/docs/security-baseline.md
+++ b/docs/security-baseline.md
@@ -58,6 +58,13 @@ Secrets to protect:
 - `AGENT_SHARED_TOKEN` (bootstrap registration only by default)
 - `AGENT_TERMINAL_TOKEN`
 - `MFA_ENCRYPTION_KEY`
+- `POSTGRES_PASSWORD`
+
+Docker Compose requires `POSTGRES_PASSWORD`; the installer generates it for new
+deployments and writes a matching `DATABASE_URL`. Existing legacy deployments
+without this setting preserve the old database password to avoid breaking an
+initialized volume, but non-local startup guardrails reject a missing or
+placeholder database URL password.
 
 Keep `AGENT_SHARED_TOKEN_ALLOW_RUNTIME=false` after updated agents are rolled
 out. Set it to `true` only as a temporary compatibility escape hatch for old

--- a/install.sh
+++ b/install.sh
@@ -259,6 +259,8 @@ main() {
 
   docker_env="$APP_DIR/deploy/docker/.env"
   root_env="$APP_DIR/.env"
+  docker_env_existing="false"
+  [ -f "$docker_env" ] && docker_env_existing="true"
   [ -f "$docker_env" ] || cp "$APP_DIR/deploy/docker/env.example" "$docker_env"
   [ -f "$root_env" ] || cp "$APP_DIR/env.example" "$root_env"
 
@@ -317,6 +319,30 @@ main() {
     info "Preserved existing AGENT_TERMINAL_TOKEN"
   fi
 
+  current_postgres_password="$(get_env_value "$docker_env" "POSTGRES_PASSWORD")"
+  current_database_url="$(get_env_value "$docker_env" "DATABASE_URL")"
+  if [ "$docker_env_existing" = "true" ] && [ -z "$current_postgres_password" ] && [ -z "$current_database_url" ]; then
+    postgres_password="fleet"
+    warn "Existing Docker env has no POSTGRES_PASSWORD; preserving legacy database password. Rotate it before production/non-local use."
+  elif is_placeholder_value "$current_postgres_password"; then
+    postgres_password="$(random_hex 24)"
+  elif confirm "Postgres password already exists. Rotate it now? Existing database volume may need manual migration if rotated." "n"; then
+    postgres_password="$(random_hex 24)"
+  else
+    postgres_password="$current_postgres_password"
+    info "Preserved existing POSTGRES_PASSWORD"
+  fi
+
+  case "$current_database_url" in
+    ""|*fleet:fleet@db*|*change-me*@db*)
+      database_url="postgresql+psycopg://fleet:${postgres_password}@db:5432/fleet"
+      ;;
+    *)
+      database_url="$current_database_url"
+      info "Preserved existing DATABASE_URL"
+      ;;
+  esac
+
   deploy_hosts="$(prompt "Managed hosts to deploy agent to now (space/comma separated, blank to skip)" "")"
   ansible_user=""
   if [ -n "$deploy_hosts" ]; then
@@ -351,6 +377,8 @@ main() {
   set_env_value "$docker_env" "ALLOW_INSECURE_NO_AGENT_TOKEN" "$allow_insecure_no_agent_token"
   set_env_value "$docker_env" "DB_AUTO_CREATE_TABLES" "$db_auto_create_tables"
   set_env_value "$docker_env" "DB_REQUIRE_MIGRATIONS_UP_TO_DATE" "true"
+  set_env_value "$docker_env" "POSTGRES_PASSWORD" "$postgres_password"
+  set_env_value "$docker_env" "DATABASE_URL" "$database_url"
   set_env_value "$docker_env" "AGENT_TERMINAL_TOKEN" "$terminal_token"
   set_env_value "$docker_env" "AGENT_TERMINAL_SCHEME" "$agent_terminal_scheme"
   set_env_value "$docker_env" "HIGH_RISK_APPROVAL_ENABLED" "true"

--- a/server/app/app_factory.py
+++ b/server/app/app_factory.py
@@ -84,6 +84,8 @@ def _is_non_local_deployment() -> bool:
 
 
 def _enforce_non_local_security_guardrails() -> None:
+    from urllib.parse import urlparse
+
     from .config import settings
 
     if not _is_non_local_deployment():
@@ -107,6 +109,14 @@ def _enforce_non_local_security_guardrails() -> None:
 
     if bool(getattr(settings, "db_auto_create_tables", True)):
         failures.append("DB_AUTO_CREATE_TABLES must be false in non-local deployments")
+
+    try:
+        parsed_db = urlparse(str(getattr(settings, "database_url", "") or ""))
+        db_password = parsed_db.password
+    except Exception:
+        db_password = None
+    if _is_placeholder_secret(db_password):
+        failures.append("DATABASE_URL password is missing or placeholder")
 
     terminal_token = getattr(settings, "agent_terminal_token", None)
     terminal_scheme = str(getattr(settings, "agent_terminal_scheme", "ws") or "ws").lower()

--- a/server/tests/test_startup_guardrails.py
+++ b/server/tests/test_startup_guardrails.py
@@ -9,7 +9,7 @@ def test_explicit_insecure_dev_mode_treats_compose_db_host_as_local(monkeypatch)
     app_factory = importlib.import_module("app.app_factory")
 
     monkeypatch.setattr(config_mod.settings, "allow_insecure_no_agent_token", True)
-    monkeypatch.setattr(config_mod.settings, "database_url", "postgresql+psycopg://fleet:fleet@db:5432/fleet")
+    monkeypatch.setattr(config_mod.settings, "database_url", "postgresql+psycopg://fleet:real-db-password@db:5432/fleet")
 
     assert app_factory._is_non_local_deployment() is False
 
@@ -70,6 +70,23 @@ def test_non_local_terminal_token_rejects_placeholder(monkeypatch):
         app_factory._enforce_non_local_security_guardrails()
 
 
+def test_non_local_database_url_rejects_placeholder_password(monkeypatch):
+    config_mod = importlib.import_module("app.config")
+    app_factory = importlib.import_module("app.app_factory")
+
+    monkeypatch.setattr(config_mod.settings, "allow_insecure_no_agent_token", False)
+    monkeypatch.setattr(config_mod.settings, "database_url", "postgresql+psycopg://fleet:fleet@db:5432/fleet")
+    monkeypatch.setattr(config_mod.settings, "bootstrap_password", "real-bootstrap-password")
+    monkeypatch.setattr(config_mod.settings, "agent_shared_token", "real-agent-token")
+    monkeypatch.setattr(config_mod.settings, "mfa_require_for_privileged", False)
+    monkeypatch.setattr(config_mod.settings, "ui_cookie_secure", True)
+    monkeypatch.setattr(config_mod.settings, "db_auto_create_tables", False)
+    monkeypatch.setattr(config_mod.settings, "agent_terminal_token", None)
+
+    with pytest.raises(RuntimeError, match="DATABASE_URL password is missing or placeholder"):
+        app_factory._enforce_non_local_security_guardrails()
+
+
 def test_docker_compose_defaults_require_agent_token():
     root = Path(__file__).resolve().parents[2]
     for rel_path in ("deploy/docker/docker-compose.yml", "deploy/docker/env.example"):
@@ -112,3 +129,16 @@ def test_new_deployments_enable_high_risk_approval_by_default():
     assert "HIGH_RISK_APPROVAL_ENABLED=true" in env_example
     assert 'set_env_value "$docker_env" "HIGH_RISK_APPROVAL_ENABLED" "true"' in install_script
     assert 'set_env_value "$docker_env" "HIGH_RISK_APPROVAL_ACTIONS" "dist-upgrade,security-campaign"' in install_script
+
+
+def test_new_deployments_require_generated_postgres_password():
+    root = Path(__file__).resolve().parents[2]
+    compose = (root / "deploy/docker/docker-compose.yml").read_text(encoding="utf-8")
+    env_example = (root / "deploy/docker/env.example").read_text(encoding="utf-8")
+    install_script = (root / "install.sh").read_text(encoding="utf-8")
+
+    assert "POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?set POSTGRES_PASSWORD in deploy/docker/.env}" in compose
+    assert "fleet:fleet@db" not in compose
+    assert "POSTGRES_PASSWORD=change-me-postgres-password" in env_example
+    assert 'set_env_value "$docker_env" "POSTGRES_PASSWORD" "$postgres_password"' in install_script
+    assert 'set_env_value "$docker_env" "DATABASE_URL" "$database_url"' in install_script


### PR DESCRIPTION
## Summary
- Require POSTGRES_PASSWORD in Docker Compose instead of falling back to fleet/fleet
- Have install.sh generate/preserve POSTGRES_PASSWORD and write a matching DATABASE_URL
- Add non-local startup guardrail for missing/placeholder DATABASE_URL passwords
- Document DB secret handling and legacy-volume preservation behavior

## Tests
- .venv/bin/python -m pytest server/tests/test_startup_guardrails.py
- bash -n install.sh script.sh
- git diff --check
- docker compose --env-file deploy/docker/env.example -f deploy/docker/docker-compose.yml config