### PR TITLE
Fix installer Postgres sync and runtime log errors

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -236,6 +236,7 @@ docker_compose() {
 
 sync_postgres_password() {
   password="$1"
+  escaped_password="$(printf '%s' "$password" | sed "s/'/''/g")"
   info "Synchronizing bundled Postgres role password"
   i=0
   while [ "$i" -lt 60 ]; do
@@ -251,7 +252,7 @@ sync_postgres_password() {
     return 1
   fi
 
-  if docker_compose exec -T db psql -v ON_ERROR_STOP=1 -U fleet -d fleet -v new_password="$password" -c "ALTER USER fleet WITH PASSWORD :'new_password';" >/dev/null; then
+  if printf "ALTER USER fleet WITH PASSWORD '%s';\n" "$escaped_password" | docker_compose exec -T db psql -v ON_ERROR_STOP=1 -U fleet -d fleet >/dev/null; then
     info "Bundled Postgres role password is in sync"
   else
     warn "Could not synchronize bundled Postgres password. Check: cd $APP_DIR/deploy/docker && docker compose logs db"

--- a/server/app/services/agent_auth.py
+++ b/server/app/services/agent_auth.py
@@ -7,6 +7,7 @@ import time
 from fastapi import Depends, HTTPException, Request
 from sqlalchemy import select
 from sqlalchemy.orm import Session
+from starlette.requests import ClientDisconnect
 
 from ..config import settings
 from ..db import get_db
@@ -55,7 +56,10 @@ async def _verify_agent_hmac(request: Request, token_hash: str) -> tuple[bool, s
     if abs(int(time.time()) - ts) > max(1, max_skew):
         return False, "stale_hmac_timestamp"
 
-    body = await request.body()
+    try:
+        body = await request.body()
+    except ClientDisconnect:
+        return False, "client_disconnected"
     body_hash = hashlib.sha256(body or b"").hexdigest()
     msg = "\n".join(
         [

--- a/server/app/services/cronjobs.py
+++ b/server/app/services/cronjobs.py
@@ -135,7 +135,9 @@ async def _dispatch_one(db: Session, cj: CronJob) -> None:
                 campaign = create_patch_campaign(
                     db=db,
                     kind="security-updates",
-                    selector={"agent_ids": agent_ids},
+                    labels=None,
+                    agent_ids=agent_ids,
+                    rings=None,
                     window_start=window_start,
                     window_end=window_end,
                     concurrency=5,

--- a/server/tests/test_agent_auth_hardening.py
+++ b/server/tests/test_agent_auth_hardening.py
@@ -1,11 +1,13 @@
 import hashlib
 import hmac
 import importlib
+import asyncio
 import sys
 import time
 
 from fastapi.routing import APIRoute
 from fastapi.testclient import TestClient
+from starlette.requests import ClientDisconnect
 
 
 def _reload_app_modules():
@@ -228,6 +230,31 @@ def test_per_agent_hmac_can_be_required(monkeypatch):
         }
         ok = client.post(target, headers=signed_headers)
         assert ok.status_code == 200, ok.text
+
+
+def test_agent_hmac_body_disconnect_is_auth_failure(monkeypatch):
+    app = _boot_app(monkeypatch, insecure_no_token=False, token='shared-secret-123', hmac_required=True)
+    del app
+    agent_auth = importlib.import_module('app.services.agent_auth')
+    token = 'per-agent-token'
+    target = '/agent/heartbeat?agent_id=srv-disconnect'
+
+    class _URL:
+        path = '/agent/heartbeat'
+        query = 'agent_id=srv-disconnect'
+
+    class _Request:
+        method = 'POST'
+        url = _URL()
+        headers = _agent_hmac_headers(token, 'POST', target)
+
+        async def body(self):
+            raise ClientDisconnect()
+
+    ok, reason = asyncio.run(agent_auth._verify_agent_hmac(_Request(), agent_auth.hash_agent_token(token)))
+
+    assert ok is False
+    assert reason == 'client_disconnected'
 
 
 def test_shared_token_can_rebind_existing_agent_during_migration(monkeypatch):

--- a/server/tests/test_cronjob_visibility.py
+++ b/server/tests/test_cronjob_visibility.py
@@ -1,5 +1,13 @@
 import importlib
+import asyncio
+import sys
 from datetime import datetime, timedelta, timezone
+
+
+def _reload_app_modules():
+    for name in list(sys.modules.keys()):
+        if name == "app" or name.startswith("app."):
+            sys.modules.pop(name, None)
 
 
 def test_admin_sees_all_cronjobs_and_regular_user_sees_only_own(monkeypatch):
@@ -12,6 +20,7 @@ def test_admin_sees_all_cronjobs_and_regular_user_sees_only_own(monkeypatch):
     monkeypatch.setenv("DB_AUTO_CREATE_TABLES", "true")
     monkeypatch.setenv("DB_REQUIRE_MIGRATIONS_UP_TO_DATE", "false")
     monkeypatch.setenv("MFA_REQUIRE_FOR_PRIVILEGED", "false")
+    _reload_app_modules()
 
     app_factory = importlib.import_module("app.app_factory")
     app = app_factory.create_app()
@@ -120,3 +129,56 @@ def test_admin_sees_all_cronjobs_and_regular_user_sees_only_own(monkeypatch):
         owners = {it["id"]: it.get("owner_username") for it in admin_items}
         assert owners[admin_cron_id] == "admin"
         assert owners[user_cron_id] == "op1"
+
+
+def test_security_campaign_cronjob_dispatch_creates_patch_campaign(monkeypatch):
+    monkeypatch.setenv("DATABASE_URL", "sqlite+pysqlite:///:memory:")
+    monkeypatch.setenv("BOOTSTRAP_USERNAME", "admin")
+    monkeypatch.setenv("BOOTSTRAP_PASSWORD", "admin-password-123")
+    monkeypatch.setenv("UI_COOKIE_SECURE", "false")
+    monkeypatch.setenv("ALLOW_INSECURE_NO_AGENT_TOKEN", "true")
+    monkeypatch.setenv("AGENT_SHARED_TOKEN", "")
+    monkeypatch.setenv("DB_AUTO_CREATE_TABLES", "true")
+    monkeypatch.setenv("DB_REQUIRE_MIGRATIONS_UP_TO_DATE", "false")
+    monkeypatch.setenv("MFA_REQUIRE_FOR_PRIVILEGED", "false")
+    _reload_app_modules()
+
+    app_factory = importlib.import_module("app.app_factory")
+    app = app_factory.create_app()
+
+    from fastapi.testclient import TestClient
+
+    with TestClient(app):
+        db_mod = importlib.import_module("app.db")
+        models = importlib.import_module("app.models")
+        cronjobs = importlib.import_module("app.services.cronjobs")
+
+        with db_mod.SessionLocal() as db:
+            user = models.AppUser(username="cron-admin", password_hash="x", role="admin")
+            db.add(user)
+            db.flush()
+            db.add(models.Host(agent_id="srv-sec", hostname="srv-sec", labels={}))
+            db.add(
+                models.CronJob(
+                    user_id=user.id,
+                    name="security now",
+                    run_at=datetime.now(timezone.utc) - timedelta(minutes=1),
+                    action="security-campaign",
+                    payload={},
+                    selector={"agent_ids": ["srv-sec"]},
+                    status="scheduled",
+                )
+            )
+            db.commit()
+
+        asyncio.run(cronjobs._run_tick())
+
+        with db_mod.SessionLocal() as db:
+            campaign = db.query(models.PatchCampaign).one()
+            assert campaign.selector == {"labels": None, "agent_ids": ["srv-sec"]}
+            assert campaign.created_by == "cron"
+            cron = db.query(models.CronJob).filter_by(name="security now").one()
+            assert cron.status == "done"
+            run = db.query(models.CronJobRun).one()
+            assert run.status == "success"
+            assert run.job_key == f"patch-campaign:{campaign.campaign_key}"

--- a/server/tests/test_startup_guardrails.py
+++ b/server/tests/test_startup_guardrails.py
@@ -143,4 +143,7 @@ def test_new_deployments_require_generated_postgres_password():
     assert 'set_env_value "$docker_env" "POSTGRES_PASSWORD" "$postgres_password"' in install_script
     assert 'set_env_value "$docker_env" "DATABASE_URL" "$database_url"' in install_script
     assert 'sync_postgres_password "$postgres_password"' in install_script
-    assert "ALTER USER fleet WITH PASSWORD :'new_password';" in install_script
+    assert 'ALTER USER fleet WITH PASSWORD' in install_script
+    assert 'escaped_password=' in install_script
+    assert ":'new_password'" not in install_script
+    assert '-c "ALTER USER fleet WITH PASSWORD' not in install_script


### PR DESCRIPTION
## Summary
- sync bundled Postgres role password during install without psql colon-variable syntax
- fix security-campaign cron dispatch to match the current patch campaign API
- handle agent HMAC request body disconnects without ASGI tracebacks

## Tests
- sh -n install.sh
- bash -n install.sh script.sh add-host.sh
- python -m pytest server/tests/test_startup_guardrails.py server/tests/test_cronjob_visibility.py server/tests/test_agent_auth_hardening.py