### PR TITLE
Show terminal access policy in host actions

### DIFF
--- a/server/app/templates/fleet-phase3-host-actions.js
+++ b/server/app/templates/fleet-phase3-host-actions.js
@@ -94,6 +94,54 @@
     }
   }
 
+  function terminalAccessPolicy(host) {
+    const labels = (host && typeof host.labels === 'object' && host.labels) ? host.labels : {};
+    const raw = String(labels.terminal_access || 'all').trim().toLowerCase();
+    const value = raw === 'disabled' ? 'none' : (raw || 'all');
+    if (value === 'admin') {
+      return {
+        value,
+        label: 'Terminal: admins only',
+        title: 'Host label terminal_access=admin allows admins only.',
+        operatorBlocked: true,
+      };
+    }
+    if (value === 'none') {
+      return {
+        value,
+        label: 'Terminal: restricted',
+        title: 'Host label terminal_access=none blocks operator console access.',
+        operatorBlocked: true,
+      };
+    }
+    return {
+      value: 'all',
+      label: 'Terminal: operators allowed',
+      title: 'Default terminal policy: admins and operators can open console.',
+      operatorBlocked: false,
+    };
+  }
+
+  function updateTerminalAccessIndicator(host, permissions) {
+    const policy = terminalAccessPolicy(host);
+    const badge = document.getElementById('host-terminal-policy');
+    const button = document.getElementById('host-action-terminal');
+    const role = String((permissions && permissions.role) || '').toLowerCase();
+    const canUseTerminal = !permissions || permissions.can_use_terminal !== false;
+    const blockedForCurrentUser = !canUseTerminal || (role === 'operator' && policy.operatorBlocked);
+
+    if (badge) {
+      badge.textContent = policy.label;
+      badge.title = policy.title;
+    }
+    if (button) {
+      button.disabled = !!blockedForCurrentUser;
+      button.title = blockedForCurrentUser ? policy.title : '';
+      button.setAttribute('aria-disabled', blockedForCurrentUser ? 'true' : 'false');
+    }
+    return policy;
+  }
+
   function formatDiskCleanupResult(data) {
     const lines = [];
     const dryRun = !!data?.dry_run;
@@ -286,6 +334,8 @@
     initHostMetadataEditor: initHostMetadataEditor,
     populateHostMetadataEditor: populateHostMetadataEditor,
     populateDiskCleanupPanel: populateDiskCleanupPanel,
+    terminalAccessPolicy: terminalAccessPolicy,
+    updateTerminalAccessIndicator: updateTerminalAccessIndicator,
     initDiskCleanupControls: initDiskCleanupControls,
     initCommonModalDismissHandlers: initCommonModalDismissHandlers,
   };

--- a/server/app/templates/index.html
+++ b/server/app/templates/index.html
@@ -89,6 +89,7 @@
 
       <div class="host-actions" id="host-actions" style="display: none; padding-top: 0; margin-top: -0.35rem; margin-bottom: 0.75rem;">
         <button class="btn btn-primary host-action-btn" id="host-action-terminal" type="button">Console</button>
+        <span id="host-terminal-policy" class="status-muted" style="align-self:center;font-size:0.82rem;"></span>
         <button class="btn btn-primary host-action-btn" id="host-action-users" type="button">Accounts</button>
         <button class="btn btn-primary host-action-btn" id="host-action-services" type="button">Services</button>
         <button class="btn btn-primary host-action-btn" id="host-action-firewall" type="button">Firewall</button>
@@ -2069,6 +2070,9 @@
         }
         if (hostActionsMod && typeof hostActionsMod.populateDiskCleanupPanel === 'function') {
           hostActionsMod.populateDiskCleanupPanel(hostObj || { agent_id: agentId, hostname });
+        }
+        if (hostActionsMod && typeof hostActionsMod.updateTerminalAccessIndicator === 'function') {
+          hostActionsMod.updateTerminalAccessIndicator(hostObj || { agent_id: agentId, hostname }, currentPermissions);
         }
       } catch (_) { }
 
@@ -4880,6 +4884,10 @@
 
               const headerNameEl = document.getElementById('server-info-hostname');
               if (headerNameEl && updatedHost.hostname) headerNameEl.textContent = String(updatedHost.hostname);
+              const hostActionsMod = window.phase3HostActions;
+              if (hostActionsMod && typeof hostActionsMod.updateTerminalAccessIndicator === 'function') {
+                hostActionsMod.updateTerminalAccessIndicator(updatedHost, currentPermissions);
+              }
             }
 
             rebuildLabelFilterOptions(allHosts);

--- a/server/tests/frontend/terminal-policy-visibility.test.js
+++ b/server/tests/frontend/terminal-policy-visibility.test.js
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+describe('terminal policy visibility', () => {
+  const root = path.resolve(path.dirname(new URL(import.meta.url).pathname), '../../..');
+
+  it('shows terminal access policy next to the Console action', () => {
+    const src = fs.readFileSync(path.join(root, 'server/app/templates/index.html'), 'utf8');
+
+    expect(src).toContain('id="host-terminal-policy"');
+    expect(src).toContain('updateTerminalAccessIndicator(hostObj');
+    expect(src).toContain('updateTerminalAccessIndicator(updatedHost');
+  });
+
+  it('maps terminal_access labels into operator-visible policy states', () => {
+    const src = fs.readFileSync(path.join(root, 'server/app/templates/fleet-phase3-host-actions.js'), 'utf8');
+
+    expect(src).toContain('function terminalAccessPolicy(host)');
+    expect(src).toContain("labels.terminal_access || 'all'");
+    expect(src).toContain('Terminal: operators allowed');
+    expect(src).toContain('Terminal: admins only');
+    expect(src).toContain('Terminal: restricted');
+    expect(src).toContain("role === 'operator' && policy.operatorBlocked");
+  });
+});


### PR DESCRIPTION
## Summary
- show the effective terminal access policy next to the Console host action
- disable the Console button for operators/read-only users when the current policy blocks them
- add frontend coverage for terminal policy visibility

## Tests
- npm run test:frontend -- server/tests/frontend/terminal-policy-visibility.test.js server/tests/frontend/terminal-input-transport.test.js
- ./.venv/bin/python -m pytest server/tests/test_terminal_audit.py server/tests/test_terminal_pipe_transport.py server/tests/test_startup_guardrails.py
- git diff --check