### PR TITLE
Make installer updates explicit and safe

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,15 +83,99 @@ networks.
 
 ## Install the Admin Node
 
+### Red Hat-family preparation
+
+On Red Hat, Rocky Linux, AlmaLinux, and other `dnf`-based systems, install the
+required packages manually before running `install.sh`. The installer installs
+OS packages automatically only on `apt`-based systems.
+
+Remove Docker packages that conflict with Docker CE:
+
+```bash
+sudo dnf remove -y \
+  docker \
+  docker-client \
+  docker-client-latest \
+  docker-common \
+  docker-latest \
+  docker-latest-logrotate \
+  docker-logrotate \
+  docker-engine \
+  podman \
+  runc
+```
+
+Install the repository helper and add Docker's official repository:
+
+```bash
+sudo dnf install -y dnf-plugins-core
+
+sudo dnf config-manager --add-repo \
+  https://download.docker.com/linux/rhel/docker-ce.repo
+```
+
+Install the application prerequisites:
+
+```bash
+sudo dnf install -y \
+  git \
+  curl \
+  ca-certificates \
+  python3 \
+  openssl \
+  ansible-core \
+  golang \
+  docker-ce \
+  docker-ce-cli \
+  containerd.io \
+  docker-buildx-plugin \
+  docker-compose-plugin
+
+sudo systemctl enable --now docker
+sudo usermod -aG docker "$USER"
+```
+
+Log out and back in after adding the current user to the `docker` group, or
+start a new group-aware shell with `newgrp docker`. Confirm that Docker works
+before continuing:
+
+```bash
+docker version
+docker compose version
+```
+
+### Prepare SSH access to managed hosts
+
+The admin node must be able to SSH to every managed host with a user that has
+`sudo` rights. Password authentication can be used during attachment, but SSH
+keys are recommended.
+
+On the admin node, create a key if needed and copy it to each target host:
+
+```bash
+ssh-keygen
+ssh-copy-id sudo-user@<IP-or-FQDN>
+```
+
+Verify both SSH and sudo access before running the installer:
+
+```bash
+ssh sudo-user@<IP-or-FQDN>
+sudo -v
+```
+
+### Run the installer
+
 Run the installer on the server that will host the web UI:
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/impsik/linux-central-management/main/install.sh | sh
 ```
 
-The installer clones or updates the repository, installs required packages,
-creates configuration files, prepares TLS certificates, runs database
-migrations, and starts the application with Docker Compose.
+The installer clones or updates the repository, installs required packages on
+supported `apt`-based systems, creates configuration files, prepares TLS
+certificates, runs database migrations, and starts the application with Docker
+Compose.
 
 ### Installer questions
 

--- a/README.md
+++ b/README.md
@@ -194,9 +194,33 @@ The helper asks for the new host addresses and SSH credentials, then:
 
 `add-host.sh` does not install nginx on managed hosts.
 
-## Rerun or Update
+## Update an Existing Installation
 
-It is safe to rerun the installer:
+Run the installed copy of the installer on the admin node:
+
+```bash
+cd ~/linux-central-management
+./install.sh
+```
+
+The update process is the same whether `install.sh` is started inside the
+repository or downloaded again with `curl`. For an existing checkout it:
+
+1. checks that tracked files have no local modifications;
+2. runs `git fetch origin --prune`;
+3. checks out the configured ref (`main` by default);
+4. runs `git pull --ff-only origin main`;
+5. when new commits were downloaded, restarts once using the updated
+   `install.sh`;
+6. preserves existing configuration and secrets unless rotation is explicitly
+   selected;
+7. rebuilds and restarts the Docker Compose services.
+
+If tracked files contain local changes, the installer stops before updating.
+Review and commit or stash those changes, then rerun it. It never performs a
+hard reset or silently overwrites local work.
+
+To update from another directory, the download command is also supported:
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/impsik/linux-central-management/main/install.sh | sh

--- a/install.sh
+++ b/install.sh
@@ -160,16 +160,13 @@ install_packages() {
 ensure_repo() {
   if [ -f "server/app/main.py" ] && [ -f "deploy/docker/docker-compose.yml" ]; then
     APP_DIR="$(pwd)"
-    info "Using existing checkout: $APP_DIR"
+    update_existing_checkout
     return
   fi
 
   if [ -d "$INSTALL_DIR/.git" ]; then
     APP_DIR="$INSTALL_DIR"
-    info "Updating existing checkout: $APP_DIR"
-    git -C "$APP_DIR" fetch origin --prune
-    git -C "$APP_DIR" checkout "$INSTALL_REF"
-    git -C "$APP_DIR" pull --ff-only origin "$INSTALL_REF"
+    update_existing_checkout
     return
   fi
 
@@ -177,6 +174,30 @@ ensure_repo() {
   mkdir -p "$(dirname "$INSTALL_DIR")"
   git clone --branch "$INSTALL_REF" "$REPO_URL" "$INSTALL_DIR"
   APP_DIR="$INSTALL_DIR"
+}
+
+update_existing_checkout() {
+  info "Checking for updates in: $APP_DIR"
+  if ! git -C "$APP_DIR" diff --quiet || ! git -C "$APP_DIR" diff --cached --quiet; then
+    err "Tracked local changes found in $APP_DIR. Commit or stash them before updating."
+  fi
+
+  previous_head="$(git -C "$APP_DIR" rev-parse HEAD)"
+  git -C "$APP_DIR" fetch origin --prune
+  git -C "$APP_DIR" checkout "$INSTALL_REF"
+  git -C "$APP_DIR" pull --ff-only origin "$INSTALL_REF"
+  current_head="$(git -C "$APP_DIR" rev-parse HEAD)"
+
+  if [ "$previous_head" = "$current_head" ]; then
+    info "Application checkout is already up to date"
+    return
+  fi
+
+  info "Updated application checkout: $previous_head -> $current_head"
+  if [ "${FLEET_INSTALL_REEXEC:-0}" != "1" ]; then
+    info "Restarting with the updated installer"
+    FLEET_INSTALL_REEXEC=1 exec "$APP_DIR/install.sh" "$@"
+  fi
 }
 
 get_env_value() {

--- a/server/app/version.py
+++ b/server/app/version.py
@@ -1,1 +1,1 @@
-APP_VERSION = "0.0.19-alpha"
+APP_VERSION = "0.0.20-alpha"

--- a/server/tests/frontend/page-shell-overflow.test.js
+++ b/server/tests/frontend/page-shell-overflow.test.js
@@ -12,6 +12,6 @@ describe('page shell release details', () => {
   });
 
   it('shows the next application version', () => {
-    expect(version).toContain('APP_VERSION = "0.0.19-alpha"');
+    expect(version).toContain('APP_VERSION = "0.0.20-alpha"');
   });
 });


### PR DESCRIPTION
## Summary
- update existing checkouts even when install.sh is run from inside the repository
- stop before updating when tracked local changes exist
- use fetch and pull --ff-only without destructive resets
- restart once with the newly downloaded installer
- document the exact update flow in README

## Validation
- clean-checkout fast-forward test with a temporary Git remote
- dirty-checkout rejection test
- sh -n install.sh
- git diff --check
- frontend tests: 31 files, 81 tests