### PR TITLE
Support initial agents in unattended installs

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,7 +317,23 @@ certificates to be renewed without changing trust stores.
 ## Non-interactive Defaults
 
 The installer is interactive when a terminal is available. Common values can
-also be supplied through environment variables, including:
+also be supplied through environment variables.
+
+### Supported setup variables
+
+- `FLEET_HOSTNAME` — application hostname without a scheme or path;
+- `FLEET_SERVER_IP` — admin node IPv4 address;
+- `FLEET_CA_CERT` — internal CA certificate path;
+- `INSTALL_NGINX` — `yes` or `no`;
+- `ATTACH_HOSTS` — one or more initial managed-host IP addresses or hostnames,
+  separated by spaces or commas;
+- `ANSIBLE_USER` — SSH user used to install the agent on initial hosts;
+- `INSTALL_DIR` — repository/install directory, defaulting to
+  `~/linux-central-management`;
+- `INSTALL_REF` — Git branch or ref to install, defaulting to `main`;
+- `REPO_URL` — alternate Git repository URL.
+
+### Install the admin node without attaching an agent
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/impsik/linux-central-management/main/install.sh | \
@@ -326,6 +342,42 @@ curl -fsSL https://raw.githubusercontent.com/impsik/linux-central-management/mai
   INSTALL_NGINX=yes \
   sh
 ```
+
+### Install the admin node and attach the first agent
+
+Prepare SSH key access from the admin node to the managed host first. Then run:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/impsik/linux-central-management/main/install.sh | \
+  FLEET_HOSTNAME=fleet.example.internal \
+  FLEET_SERVER_IP=192.0.2.10 \
+  INSTALL_NGINX=yes \
+  ATTACH_HOSTS=192.0.2.21 \
+  ANSIBLE_USER=fleet-admin \
+  sh
+```
+
+This example installs the control plane on `192.0.2.10` and deploys
+`fleet-agent` to `192.0.2.21` over SSH as `fleet-admin`. The SSH user must have
+working `sudo` access. With key-based SSH and passwordless sudo, no host-login
+password prompt is required.
+
+Multiple initial agents can be supplied as one quoted value:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/impsik/linux-central-management/main/install.sh | \
+  FLEET_HOSTNAME=fleet.example.internal \
+  FLEET_SERVER_IP=192.0.2.10 \
+  INSTALL_NGINX=yes \
+  ATTACH_HOSTS='192.0.2.21 192.0.2.22 server23.example.internal' \
+  ANSIBLE_USER=fleet-admin \
+  sh
+```
+
+The bootstrap admin password is still generated securely when no existing
+password is configured. The installer displays a newly generated password in
+its final summary. Browser terminal access remains an explicit interactive
+opt-in and is not enabled merely by using non-interactive defaults.
 
 Review `install.sh` before unattended production use. Secret rotation and host
 attachment deliberately retain confirmation steps where appropriate.

--- a/install.sh
+++ b/install.sh
@@ -622,10 +622,10 @@ main() {
       ;;
   esac
 
-  deploy_hosts="$(prompt "Managed hosts to deploy agent to now (space/comma separated, blank to skip)" "")"
+  deploy_hosts="${ATTACH_HOSTS:-$(prompt "Managed hosts to deploy agent to now (space/comma separated, blank to skip)" "")}"
   ansible_user=""
   if [ -n "$deploy_hosts" ]; then
-    ansible_user="$(prompt "SSH username for managed hosts" "$(id -un 2>/dev/null || printf ubuntu)")"
+    ansible_user="${ANSIBLE_USER:-$(prompt "SSH username for managed hosts" "$(id -un 2>/dev/null || printf ubuntu)")}"
   fi
 
   case "$server_url" in

--- a/server/app/version.py
+++ b/server/app/version.py
@@ -1,1 +1,1 @@
-APP_VERSION = "0.0.20-alpha"
+APP_VERSION = "0.0.21-alpha"

--- a/server/tests/frontend/page-shell-overflow.test.js
+++ b/server/tests/frontend/page-shell-overflow.test.js
@@ -12,6 +12,6 @@ describe('page shell release details', () => {
   });
 
   it('shows the next application version', () => {
-    expect(version).toContain('APP_VERSION = "0.0.20-alpha"');
+    expect(version).toContain('APP_VERSION = "0.0.21-alpha"');
   });
 });


### PR DESCRIPTION
## Summary
- allow install.sh to read initial managed hosts from ATTACH_HOSTS
- allow the initial SSH user to be supplied through ANSIBLE_USER
- document supported non-interactive variables
- add single-agent and multi-agent installation examples
- bump application version to 0.0.21-alpha

## Validation
- sh -n install.sh
- git diff --check
- frontend tests: 31 files, 81 tests