### PR TITLE
Add security mitigation assessment and remediation

### DIFF
--- a/agent/cmd/fleet-agent/main.go
+++ b/agent/cmd/fleet-agent/main.go
@@ -964,8 +964,11 @@ func handleJob(ctx context.Context, client *http.Client, serverURL, agentID stri
 	}, token)
 }
 
+var securityMitigationModprobeDir = "/etc/modprobe.d"
+
 func runSecurityMitigation(ctx context.Context, mitigationID string, version int, action string) (string, string, int, string) {
-	if strings.TrimSpace(action) != "assess" {
+	action = strings.TrimSpace(action)
+	if action != "assess" && action != "apply" {
 		return "", "", 2, "security mitigation action is not allowed by this agent version"
 	}
 	if mitigationID != "linux-rds-disable" || version != 1 {
@@ -975,7 +978,37 @@ func runSecurityMitigation(ctx context.Context, mitigationID string, version int
 	result := map[string]any{
 		"mitigation_id": mitigationID,
 		"version":       version,
-		"action":        "assess",
+		"action":        action,
+	}
+	if action == "apply" {
+		configPath := filepath.Join(securityMitigationModprobeDir, "fleet-disable-rds.conf")
+		config := []byte("# Managed by fleet security mitigation linux-rds-disable v1\ninstall rds /bin/false\nblacklist rds\n")
+		tmp, err := os.CreateTemp(securityMitigationModprobeDir, ".fleet-disable-rds-*")
+		if err != nil {
+			return "", "", 1, fmt.Sprintf("create mitigation config: %v", err)
+		}
+		tmpPath := tmp.Name()
+		defer os.Remove(tmpPath)
+		if err := tmp.Chmod(0644); err != nil {
+			tmp.Close()
+			return "", "", 1, fmt.Sprintf("set mitigation config permissions: %v", err)
+		}
+		if _, err := tmp.Write(config); err != nil {
+			tmp.Close()
+			return "", "", 1, fmt.Sprintf("write mitigation config: %v", err)
+		}
+		if err := tmp.Sync(); err != nil {
+			tmp.Close()
+			return "", "", 1, fmt.Sprintf("sync mitigation config: %v", err)
+		}
+		if err := tmp.Close(); err != nil {
+			return "", "", 1, fmt.Sprintf("close mitigation config: %v", err)
+		}
+		if err := os.Rename(tmpPath, configPath); err != nil {
+			return "", "", 1, fmt.Sprintf("activate mitigation config: %v", err)
+		}
+		result["config_path"] = configPath
+		result["applied"] = true
 	}
 	if _, err := exec.LookPath("modprobe"); err != nil {
 		result["status"] = "not_applicable"
@@ -1031,11 +1064,19 @@ func runSecurityMitigation(ctx context.Context, mitigationID string, version int
 	if !moduleAvailable && probeErr != nil {
 		status = "not_applicable"
 		detail = "rds kernel module is not available"
-	} else if !loaded && loadingDisabled && !bootConfigured {
+	} else if !loaded && loadingDisabled {
 		status = "mitigated"
 		detail = "rds is not loaded and automatic loading is disabled"
+		if bootConfigured {
+			detail = "rds boot-time declaration is overridden by the modprobe install rule"
+		}
 	} else if loaded {
-		detail = "rds kernel module is currently loaded"
+		if loadingDisabled {
+			status = "reboot_required"
+			detail = "automatic loading is disabled, but rds remains loaded until services release it or the host is rebooted"
+		} else {
+			detail = "rds kernel module is currently loaded"
+		}
 	} else if bootConfigured {
 		detail = "rds is configured for boot-time loading"
 	}

--- a/agent/cmd/fleet-agent/main.go
+++ b/agent/cmd/fleet-agent/main.go
@@ -15,6 +15,7 @@ import (
 	"net/url"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"runtime"
 	"strconv"
 	"strings"
@@ -79,21 +80,23 @@ type NextJobResponse struct {
 }
 
 type Job struct {
-	JobID          string   `json:"job_id"`
-	JobNonce       string   `json:"job_nonce,omitempty"`
-	Type           string   `json:"type"`
-	Packages       []string `json:"packages,omitempty"`
-	ServiceName    string   `json:"service_name,omitempty"`
-	Action         string   `json:"action,omitempty"`
-	PackageName    string   `json:"package_name,omitempty"`
-	Refresh        bool     `json:"refresh,omitempty"`
-	CVE            string   `json:"cve,omitempty"`
-	Port           int      `json:"port,omitempty"`
-	Protocol       string   `json:"protocol,omitempty"`
-	Source         string   `json:"source,omitempty"`
-	Service        string   `json:"service,omitempty"`
-	DryRun         bool     `json:"dry_run,omitempty"`
-	CleanupActions []string `json:"cleanup_actions,omitempty"`
+	JobID             string   `json:"job_id"`
+	JobNonce          string   `json:"job_nonce,omitempty"`
+	Type              string   `json:"type"`
+	Packages          []string `json:"packages,omitempty"`
+	ServiceName       string   `json:"service_name,omitempty"`
+	Action            string   `json:"action,omitempty"`
+	PackageName       string   `json:"package_name,omitempty"`
+	Refresh           bool     `json:"refresh,omitempty"`
+	CVE               string   `json:"cve,omitempty"`
+	Port              int      `json:"port,omitempty"`
+	Protocol          string   `json:"protocol,omitempty"`
+	Source            string   `json:"source,omitempty"`
+	Service           string   `json:"service,omitempty"`
+	DryRun            bool     `json:"dry_run,omitempty"`
+	CleanupActions    []string `json:"cleanup_actions,omitempty"`
+	MitigationID      string   `json:"mitigation_id,omitempty"`
+	MitigationVersion int      `json:"mitigation_version,omitempty"`
 }
 
 type JobEvent struct {
@@ -939,12 +942,116 @@ func handleJob(ctx context.Context, client *http.Client, serverURL, agentID stri
 		ev.Error = errMsg
 		mustPostJSON(client, serverURL+"/agent/job-event", ev, token)
 		return
+
+	case "security-mitigation":
+		stdout, stderr, code, errMsg := runSecurityMitigation(ctx, job.MitigationID, job.MitigationVersion, job.Action)
+		if code == 0 && errMsg == "" {
+			ev.Status = "success"
+		} else {
+			ev.Status = "failed"
+		}
+		ev.ExitCode = &code
+		ev.Stdout = stdout
+		ev.Stderr = stderr
+		ev.Error = errMsg
+		mustPostJSON(client, serverURL+"/agent/job-event", ev, token)
+		return
 	}
 
 	code := 2
 	mustPostJSON(client, serverURL+"/agent/job-event", JobEvent{
 		AgentID: agentID, JobID: job.JobID, Status: "failed", ExitCode: &code, Error: "unknown job type",
 	}, token)
+}
+
+func runSecurityMitigation(ctx context.Context, mitigationID string, version int, action string) (string, string, int, string) {
+	if strings.TrimSpace(action) != "assess" {
+		return "", "", 2, "security mitigation action is not allowed by this agent version"
+	}
+	if mitigationID != "linux-rds-disable" || version != 1 {
+		return "", "", 2, "unknown security mitigation id or version"
+	}
+
+	result := map[string]any{
+		"mitigation_id": mitigationID,
+		"version":       version,
+		"action":        "assess",
+	}
+	if _, err := exec.LookPath("modprobe"); err != nil {
+		result["status"] = "not_applicable"
+		result["detail"] = "modprobe is not available"
+		encoded, _ := json.Marshal(result)
+		return string(encoded), "", 0, ""
+	}
+
+	moduleAvailable := false
+	if modinfo, err := exec.LookPath("modinfo"); err == nil {
+		checkCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+		cmd := exec.CommandContext(checkCtx, modinfo, "rds")
+		moduleAvailable = cmd.Run() == nil
+		cancel()
+	}
+	loaded := false
+	if modules, err := os.ReadFile("/proc/modules"); err == nil {
+		for _, line := range strings.Split(string(modules), "\n") {
+			if strings.HasPrefix(line, "rds ") {
+				loaded = true
+				moduleAvailable = true
+				break
+			}
+		}
+	}
+
+	probeCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	probe := exec.CommandContext(probeCtx, "modprobe", "-n", "-v", "rds")
+	probeOutput, probeErr := probe.CombinedOutput()
+	cancel()
+	probeText := strings.TrimSpace(string(probeOutput))
+	loadingDisabled := strings.Contains(probeText, "/bin/false") || strings.Contains(probeText, "/bin/true")
+
+	bootConfigured := false
+	for _, pattern := range []string{"/etc/modules-load.d/*.conf", "/usr/lib/modules-load.d/*.conf"} {
+		paths, _ := filepath.Glob(pattern)
+		for _, path := range paths {
+			content, err := os.ReadFile(path)
+			if err != nil {
+				continue
+			}
+			for _, line := range strings.Split(string(content), "\n") {
+				line = strings.TrimSpace(strings.SplitN(line, "#", 2)[0])
+				if line == "rds" {
+					bootConfigured = true
+				}
+			}
+		}
+	}
+
+	status := "vulnerable"
+	detail := "rds can be loaded"
+	if !moduleAvailable && probeErr != nil {
+		status = "not_applicable"
+		detail = "rds kernel module is not available"
+	} else if !loaded && loadingDisabled && !bootConfigured {
+		status = "mitigated"
+		detail = "rds is not loaded and automatic loading is disabled"
+	} else if loaded {
+		detail = "rds kernel module is currently loaded"
+	} else if bootConfigured {
+		detail = "rds is configured for boot-time loading"
+	}
+
+	result["status"] = status
+	result["detail"] = detail
+	result["module_available"] = moduleAvailable
+	result["module_loaded"] = loaded
+	result["loading_disabled"] = loadingDisabled
+	result["boot_loading_configured"] = bootConfigured
+	result["modprobe_dry_run"] = probeText
+	encoded, err := json.Marshal(result)
+	if err != nil {
+		return "", "", 1, err.Error()
+	}
+	return string(encoded), "", 0, ""
 }
 
 func queryDf(ctx context.Context) (string, string, int, string) {

--- a/agent/cmd/fleet-agent/main_test.go
+++ b/agent/cmd/fleet-agent/main_test.go
@@ -323,3 +323,15 @@ func TestRunDiskCleanupRejectsUnsupportedAction(t *testing.T) {
 		t.Fatalf("error = %q, want unsupported cleanup action", errMsg)
 	}
 }
+
+func TestSecurityMitigationRejectsUnknownOrApply(t *testing.T) {
+	_, _, code, errMsg := runSecurityMitigation(context.Background(), "unknown", 1, "assess")
+	if code != 2 || errMsg == "" {
+		t.Fatalf("unknown mitigation = code %d error %q, want rejected", code, errMsg)
+	}
+
+	_, _, code, errMsg = runSecurityMitigation(context.Background(), "linux-rds-disable", 1, "apply")
+	if code != 2 || errMsg == "" {
+		t.Fatalf("apply mitigation = code %d error %q, want rejected", code, errMsg)
+	}
+}

--- a/agent/cmd/fleet-agent/main_test.go
+++ b/agent/cmd/fleet-agent/main_test.go
@@ -324,14 +324,27 @@ func TestRunDiskCleanupRejectsUnsupportedAction(t *testing.T) {
 	}
 }
 
-func TestSecurityMitigationRejectsUnknownOrApply(t *testing.T) {
+func TestSecurityMitigationRejectsUnknown(t *testing.T) {
 	_, _, code, errMsg := runSecurityMitigation(context.Background(), "unknown", 1, "assess")
 	if code != 2 || errMsg == "" {
 		t.Fatalf("unknown mitigation = code %d error %q, want rejected", code, errMsg)
 	}
+}
 
-	_, _, code, errMsg = runSecurityMitigation(context.Background(), "linux-rds-disable", 1, "apply")
-	if code != 2 || errMsg == "" {
-		t.Fatalf("apply mitigation = code %d error %q, want rejected", code, errMsg)
+func TestSecurityMitigationApplyWritesManagedConfig(t *testing.T) {
+	oldDir := securityMitigationModprobeDir
+	securityMitigationModprobeDir = t.TempDir()
+	t.Cleanup(func() { securityMitigationModprobeDir = oldDir })
+
+	stdout, _, code, errMsg := runSecurityMitigation(context.Background(), "linux-rds-disable", 1, "apply")
+	if code != 0 || errMsg != "" {
+		t.Fatalf("apply mitigation = code %d error %q", code, errMsg)
+	}
+	config, err := os.ReadFile(filepath.Join(securityMitigationModprobeDir, "fleet-disable-rds.conf"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(config), "install rds /bin/false") || !strings.Contains(stdout, `"applied":true`) {
+		t.Fatalf("unexpected mitigation result: config=%q stdout=%q", config, stdout)
 	}
 }

--- a/server/app/app_factory.py
+++ b/server/app/app_factory.py
@@ -16,7 +16,7 @@ from fastapi.staticfiles import StaticFiles
 
 from .db import Base, SessionLocal, engine
 from .deps import get_current_user_from_request
-from .routers import agent, ansible, approvals, audit, auth, backup_verification, cronjobs, dashboard, hosts, jobs, maintenance_windows, migrations, mfa, patching, reports, reports_html, search, sshkeys, terminal_ws, ui
+from .routers import agent, ansible, approvals, audit, auth, backup_verification, cronjobs, dashboard, hosts, jobs, maintenance_windows, migrations, mfa, patching, reports, reports_html, search, security_mitigations, sshkeys, terminal_ws, ui
 
 logger = logging.getLogger(__name__)
 
@@ -605,6 +605,7 @@ def create_app() -> FastAPI:
     app.include_router(dashboard.router)
     app.include_router(cronjobs.router)
     app.include_router(sshkeys.router)
+    app.include_router(security_mitigations.router)
     app.include_router(hosts.router)
     app.include_router(reports.router)
     app.include_router(reports_html.router)

--- a/server/app/routers/__init__.py
+++ b/server/app/routers/__init__.py
@@ -1,1 +1,1 @@
-from . import agent, ansible, approvals, audit, auth, backup_verification, hosts, jobs, migrations, mfa, search, terminal_ws, ui  # noqa: F401
+from . import agent, ansible, approvals, audit, auth, backup_verification, hosts, jobs, migrations, mfa, search, security_mitigations, terminal_ws, ui  # noqa: F401

--- a/server/app/routers/approvals.py
+++ b/server/app/routers/approvals.py
@@ -15,6 +15,7 @@ from ..services.audit import log_event
 from ..services.db_utils import transaction
 from ..services.jobs import create_job_with_runs, push_job_to_agents
 from ..services.patching import create_patch_campaign
+from ..services.security_mitigations import get_mitigation
 
 router = APIRouter(prefix="/approvals", tags=["approvals"])
 
@@ -251,6 +252,48 @@ async def approve_request(request_id: str, request: Request, db: Session = Depen
                     "campaign_kind": "security-updates",
                     "target_count": target_count,
                 },
+            }
+
+        if action == "security-mitigation-apply":
+            agent_ids = [str(x) for x in (p.get("agent_ids") or []) if str(x).strip()]
+            mitigation = get_mitigation(str(p.get("mitigation_id") or ""))
+            version = int(p.get("mitigation_version") or 0)
+            if not agent_ids:
+                raise HTTPException(400, "request has no targets")
+            if not mitigation or not mitigation.get("apply_available") or int(mitigation["version"]) != version:
+                raise HTTPException(400, "mitigation definition is unavailable or changed")
+
+            job_payload = {"mitigation_id": mitigation["id"], "mitigation_version": version, "action": "apply"}
+            with transaction(db):
+                created = create_job_with_runs(
+                    db=db,
+                    job_type="security-mitigation",
+                    payload=job_payload,
+                    agent_ids=agent_ids,
+                    created_by=getattr(admin, "username", None) or "admin",
+                    commit=False,
+                )
+                req.status = "executed"
+                req.execution_ref = created.job_key
+                req.finished_at = datetime.now(timezone.utc)
+                log_event(
+                    db,
+                    action="security.mitigation.apply.queued",
+                    actor=admin,
+                    request=request,
+                    target_type="security_mitigation",
+                    target_id=mitigation["id"],
+                    target_name=mitigation["name"],
+                    meta={"request_id": str(req.id), "execution_ref": created.job_key, "target_count": len(agent_ids)},
+                )
+
+            await push_job_to_agents(
+                agent_ids=agent_ids,
+                job_payload_builder=lambda aid: {"job_id": created.job_key, "type": "security-mitigation", **job_payload},
+            )
+            return {
+                "id": str(req.id), "action": req.action, "status": req.status, "execution_ref": created.job_key,
+                "summary": {"message": f"mitigation queued for {len(agent_ids)} host(s); each agent applies and verifies it", "target_count": len(agent_ids)},
             }
 
         raise HTTPException(400, "unsupported action")

--- a/server/app/routers/security_mitigations.py
+++ b/server/app/routers/security_mitigations.py
@@ -1,13 +1,17 @@
 from __future__ import annotations
 
+import json
+
 from fastapi import APIRouter, Depends, HTTPException, Request
 from pydantic import BaseModel, Field
+from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from ..db import get_db
 from ..deps import require_ui_user
 from ..services.audit import log_event
 from ..services.db_utils import transaction
+from ..models import HighRiskActionRequest, Job, JobRun
 from ..services.jobs import create_job_with_runs, push_job_to_agents
 from ..services.rbac import permissions_for
 from ..services.security_mitigations import get_mitigation, mitigation_catalog
@@ -19,6 +23,10 @@ router = APIRouter(prefix="/security/mitigations", tags=["security-mitigations"]
 class MitigationAssessmentRequest(BaseModel):
     agent_ids: list[str] = Field(default_factory=list)
     labels: dict[str, str] | None = None
+
+
+class MitigationApplyRequest(MitigationAssessmentRequest):
+    assessment_job_id: str = Field(min_length=1, max_length=160)
 
 
 @router.get("")
@@ -90,5 +98,89 @@ async def assess_mitigation(
         "mitigation_id": mitigation["id"],
         "mitigation_version": mitigation["version"],
         "action": "assess",
+        "targets": targets,
+    }
+
+
+@router.post("/{mitigation_id}/apply")
+def request_mitigation_apply(
+    mitigation_id: str,
+    payload: MitigationApplyRequest,
+    request: Request,
+    db: Session = Depends(get_db),
+    user=Depends(require_ui_user),
+):
+    perms = permissions_for(user)
+    if not perms.get("can_manage_packages"):
+        raise HTTPException(403, "Insufficient permissions to apply security mitigations")
+
+    mitigation = get_mitigation(mitigation_id)
+    if not mitigation:
+        raise HTTPException(404, "Unknown security mitigation")
+    if not mitigation.get("apply_available"):
+        raise HTTPException(400, "This mitigation does not support automated remediation")
+
+    targets = resolve_agent_ids(db, payload.agent_ids, payload.labels, user=user)
+    if not targets:
+        raise HTTPException(400, "Select at least one host within your scope")
+
+    assessment = db.execute(select(Job).where(Job.job_key == payload.assessment_job_id)).scalar_one_or_none()
+    assessment_payload = assessment.payload if assessment and isinstance(assessment.payload, dict) else {}
+    if (
+        not assessment
+        or assessment.job_type != "security-mitigation"
+        or assessment_payload.get("action") != "assess"
+        or assessment_payload.get("mitigation_id") != mitigation["id"]
+        or int(assessment_payload.get("mitigation_version") or 0) != int(mitigation["version"])
+    ):
+        raise HTTPException(400, "A matching completed assessment is required before apply")
+    runs = db.execute(select(JobRun).where(JobRun.job_id == assessment.id, JobRun.agent_id.in_(targets))).scalars().all()
+    vulnerable = set()
+    for run in runs:
+        try:
+            result = json.loads(run.stdout or "{}") if run.status == "success" else {}
+        except (TypeError, ValueError):
+            result = {}
+        if result.get("status") == "vulnerable":
+            vulnerable.add(run.agent_id)
+    if vulnerable != set(targets):
+        raise HTTPException(400, "Apply targets must all be vulnerable in the referenced completed assessment")
+
+    with transaction(db):
+        approval = HighRiskActionRequest(
+            user_id=user.id,
+            action="security-mitigation-apply",
+            payload={
+                "mitigation_id": mitigation["id"],
+                "mitigation_version": mitigation["version"],
+                "agent_ids": targets,
+                "assessment_job_id": payload.assessment_job_id,
+            },
+            status="pending",
+        )
+        db.add(approval)
+        db.flush()
+        log_event(
+            db,
+            action="security.mitigation.apply.requested",
+            actor=user,
+            request=request,
+            target_type="high_risk_action_request",
+            target_id=str(approval.id),
+            target_name=mitigation["name"],
+            meta={
+                "request_id": str(approval.id),
+                "mitigation_id": mitigation["id"],
+                "mitigation_version": mitigation["version"],
+                "assessment_job_id": payload.assessment_job_id,
+                "target_count": len(targets),
+                "agent_ids": targets,
+            },
+        )
+    return {
+        "approval_required": True,
+        "request_id": str(approval.id),
+        "action": "security-mitigation-apply",
+        "status": "pending",
         "targets": targets,
     }

--- a/server/app/routers/security_mitigations.py
+++ b/server/app/routers/security_mitigations.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, Request
+from pydantic import BaseModel, Field
+from sqlalchemy.orm import Session
+
+from ..db import get_db
+from ..deps import require_ui_user
+from ..services.audit import log_event
+from ..services.db_utils import transaction
+from ..services.jobs import create_job_with_runs, push_job_to_agents
+from ..services.rbac import permissions_for
+from ..services.security_mitigations import get_mitigation, mitigation_catalog
+from ..services.targets import resolve_agent_ids
+
+router = APIRouter(prefix="/security/mitigations", tags=["security-mitigations"])
+
+
+class MitigationAssessmentRequest(BaseModel):
+    agent_ids: list[str] = Field(default_factory=list)
+    labels: dict[str, str] | None = None
+
+
+@router.get("")
+def list_mitigations(user=Depends(require_ui_user)):
+    permissions_for(user)
+    return {"items": mitigation_catalog()}
+
+
+@router.post("/{mitigation_id}/assess")
+async def assess_mitigation(
+    mitigation_id: str,
+    payload: MitigationAssessmentRequest,
+    request: Request,
+    db: Session = Depends(get_db),
+    user=Depends(require_ui_user),
+):
+    perms = permissions_for(user)
+    if not perms.get("can_manage_packages"):
+        raise HTTPException(403, "Insufficient permissions to assess security mitigations")
+
+    mitigation = get_mitigation(mitigation_id)
+    if not mitigation:
+        raise HTTPException(404, "Unknown security mitigation")
+
+    targets = resolve_agent_ids(db, payload.agent_ids, payload.labels, user=user)
+    if not targets:
+        raise HTTPException(400, "Select at least one host within your scope")
+
+    job_payload = {
+        "mitigation_id": mitigation["id"],
+        "mitigation_version": mitigation["version"],
+        "action": "assess",
+    }
+    with transaction(db):
+        created = create_job_with_runs(
+            db=db,
+            job_type="security-mitigation",
+            payload=job_payload,
+            agent_ids=targets,
+            created_by=str(getattr(user, "username", None) or "ui"),
+            commit=False,
+        )
+        log_event(
+            db,
+            action="security.mitigation.assessment.queued",
+            actor=user,
+            request=request,
+            target_type="security_mitigation",
+            target_id=mitigation["id"],
+            target_name=mitigation["name"],
+            meta={
+                "mitigation_version": mitigation["version"],
+                "target_count": len(targets),
+                "agent_ids": targets,
+                "mode": "ASSESS",
+            },
+        )
+
+    await push_job_to_agents(
+        agent_ids=targets,
+        job_payload_builder=lambda aid: {
+            "job_id": created.job_key,
+            "type": "security-mitigation",
+            **job_payload,
+        },
+    )
+    return {
+        "job_id": created.job_key,
+        "mitigation_id": mitigation["id"],
+        "mitigation_version": mitigation["version"],
+        "action": "assess",
+        "targets": targets,
+    }

--- a/server/app/services/jobs.py
+++ b/server/app/services/jobs.py
@@ -116,6 +116,11 @@ def build_agent_job_payload(job: Job, agent_id: str) -> dict:
         out["action"] = payload.get("sudo_profile") or payload.get("action") or "B"
         out["package_name"] = payload.get("public_key") or payload.get("package_name") or ""
 
+    if job_type == "security-mitigation":
+        out["mitigation_id"] = payload.get("mitigation_id") or ""
+        out["mitigation_version"] = int(payload.get("mitigation_version") or 0)
+        out["action"] = payload.get("action") or "assess"
+
     return out
 
 

--- a/server/app/services/security_mitigations.py
+++ b/server/app/services/security_mitigations.py
@@ -16,8 +16,9 @@ MITIGATIONS: dict[str, dict] = {
                 "Whether rds is configured for boot-time loading",
             ]
         },
-        "apply_available": False,
-        "reboot_required": False,
+        "apply_available": True,
+        "approval_required": True,
+        "reboot_required": "when_loaded",
         "references": [],
     }
 }

--- a/server/app/services/security_mitigations.py
+++ b/server/app/services/security_mitigations.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+
+MITIGATIONS: dict[str, dict] = {
+    "linux-rds-disable": {
+        "id": "linux-rds-disable",
+        "version": 1,
+        "name": "Disable the Linux RDS kernel module",
+        "summary": "Assess exposure to RDS kernel module vulnerabilities such as PinTheft.",
+        "severity": "high",
+        "supported_os": ["debian", "ubuntu", "rhel", "rocky", "almalinux"],
+        "assessment": {
+            "checks": [
+                "Whether the rds module is available and currently loaded",
+                "Whether modprobe is configured to prevent loading rds",
+                "Whether rds is configured for boot-time loading",
+            ]
+        },
+        "apply_available": False,
+        "reboot_required": False,
+        "references": [],
+    }
+}
+
+
+def mitigation_catalog() -> list[dict]:
+    return [dict(item) for item in MITIGATIONS.values()]
+
+
+def get_mitigation(mitigation_id: str) -> dict | None:
+    item = MITIGATIONS.get(str(mitigation_id or "").strip())
+    return dict(item) if item else None

--- a/server/app/templates/fleet-phase3-overview.js
+++ b/server/app/templates/fleet-phase3-overview.js
@@ -1370,6 +1370,7 @@
       ctx.loadSshKeyRequests();
       ctx.maybeLoadSshKeyAdminQueue();
       ctx.loadAdminSshKeys();
+      window.fleetSecurityMitigationsUi?.load();
     }
 
     function showReportsTab() {

--- a/server/app/templates/fleet-security-mitigations-ui.js
+++ b/server/app/templates/fleet-security-mitigations-ui.js
@@ -1,0 +1,147 @@
+(function () {
+  'use strict';
+
+  let catalog = [];
+  let selectedMitigation = '';
+  let hosts = [];
+  const selectedHosts = new Set();
+
+  const esc = (value) => String(value ?? '')
+    .replaceAll('&', '&amp;').replaceAll('<', '&lt;').replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;').replaceAll("'", '&#039;');
+
+  function updateCount() {
+    const el = document.getElementById('mitigation-hosts-count');
+    if (el) el.textContent = String(selectedHosts.size);
+  }
+
+  function renderCatalog() {
+    const wrap = document.getElementById('security-mitigations-list');
+    if (!wrap) return;
+    if (!catalog.length) {
+      wrap.innerHTML = '<div class="status-muted">No mitigations are available.</div>';
+      return;
+    }
+    if (!selectedMitigation) selectedMitigation = catalog[0].id;
+    wrap.innerHTML = catalog.map((item) => `
+      <label style="display:block;border:1px solid var(--border);border-radius:10px;padding:0.75rem;margin-bottom:0.5rem;">
+        <span style="display:flex;gap:0.6rem;align-items:flex-start;">
+          <input type="radio" name="security-mitigation" value="${esc(item.id)}" ${item.id === selectedMitigation ? 'checked' : ''} />
+          <span><strong>${esc(item.name)}</strong> <code>v${esc(item.version)}</code>
+          <span class="status-warn" style="margin-left:0.4rem;">${esc(item.severity)}</span><br>
+          <span class="status-muted">${esc(item.summary)}</span><br>
+          <span class="status-muted">Apply: ${item.apply_available ? 'available with approval' : 'not enabled yet'}</span></span>
+        </span>
+      </label>`).join('');
+    wrap.querySelectorAll('input[name="security-mitigation"]').forEach((input) => {
+      input.addEventListener('change', () => { selectedMitigation = input.value; });
+    });
+  }
+
+  function renderHosts() {
+    const wrap = document.getElementById('mitigation-hosts-list');
+    if (!wrap) return;
+    if (!hosts.length) {
+      wrap.innerHTML = '<div class="status-muted">No visible hosts.</div>';
+      return;
+    }
+    wrap.innerHTML = hosts.map((host) => {
+      const id = String(host.agent_id || host.id || '');
+      const label = host.hostname || host.fqdn || id;
+      return `<label style="display:flex;gap:0.5rem;align-items:center;padding:0.3rem;">
+        <input type="checkbox" data-agent-id="${esc(id)}" ${selectedHosts.has(id) ? 'checked' : ''} />
+        <span>${esc(label)} <code>${esc(id)}</code></span>
+      </label>`;
+    }).join('');
+    wrap.querySelectorAll('input[data-agent-id]').forEach((input) => {
+      input.addEventListener('change', () => {
+        if (input.checked) selectedHosts.add(input.dataset.agentId);
+        else selectedHosts.delete(input.dataset.agentId);
+        updateCount();
+      });
+    });
+    updateCount();
+  }
+
+  function renderResults(job) {
+    const wrap = document.getElementById('mitigation-results');
+    if (!wrap) return;
+    const rows = (job.runs || []).map((run) => {
+      let result = {};
+      try { result = JSON.parse(run.stdout_tail || run.stdout || '{}'); } catch (_) { result = {}; }
+      const state = result.status || run.status;
+      const cls = state === 'mitigated' || state === 'not_applicable' ? 'status-ok' : (state === 'vulnerable' ? 'status-error' : 'status-muted');
+      return `<tr><td><code>${esc(run.agent_id)}</code></td><td class="${cls}">${esc(state)}</td><td>${esc(result.detail || run.error || '')}</td></tr>`;
+    }).join('');
+    wrap.innerHTML = `<table class="process-table"><thead><tr><th>Host</th><th>Assessment</th><th>Detail</th></tr></thead><tbody>${rows}</tbody></table>`;
+  }
+
+  async function pollJob(jobId) {
+    const status = document.getElementById('mitigation-status');
+    for (let attempt = 0; attempt < 60; attempt += 1) {
+      const response = await fetch(`/jobs/${encodeURIComponent(jobId)}`, { credentials: 'include' });
+      if (!response.ok) throw new Error(`job status failed (${response.status})`);
+      const job = await response.json();
+      renderResults(job);
+      if (job.done) {
+        if (status) status.textContent = 'Assessment complete.';
+        return;
+      }
+      if (status) status.textContent = 'Assessment running…';
+      await new Promise((resolve) => setTimeout(resolve, 1500));
+    }
+    if (status) status.textContent = 'Assessment is still running. Check Queue health for details.';
+  }
+
+  async function assess() {
+    const status = document.getElementById('mitigation-status');
+    if (!selectedMitigation) return window.showToast?.('Select a mitigation', 'error');
+    if (!selectedHosts.size) return window.showToast?.('Select at least one host', 'error');
+    const button = document.getElementById('mitigation-assess');
+    if (button) button.disabled = true;
+    try {
+      if (status) status.textContent = 'Queueing assessment…';
+      const response = await fetch(`/security/mitigations/${encodeURIComponent(selectedMitigation)}/assess`, {
+        method: 'POST', credentials: 'include', headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ agent_ids: Array.from(selectedHosts) }),
+      });
+      const body = await response.json().catch(() => ({}));
+      if (!response.ok) throw new Error(body.detail || `assessment failed (${response.status})`);
+      await pollJob(body.job_id);
+    } catch (error) {
+      if (status) status.textContent = error.message || String(error);
+      window.showToast?.(`Assessment failed: ${error.message || error}`, 'error');
+    } finally {
+      if (button) button.disabled = false;
+    }
+  }
+
+  async function load() {
+    try {
+      const [catalogResponse, hostsResponse] = await Promise.all([
+        fetch('/security/mitigations', { credentials: 'include' }),
+        fetch('/hosts?limit=500', { credentials: 'include' }),
+      ]);
+      if (!catalogResponse.ok) throw new Error(`mitigation catalog failed (${catalogResponse.status})`);
+      if (!hostsResponse.ok) throw new Error(`hosts failed (${hostsResponse.status})`);
+      catalog = (await catalogResponse.json()).items || [];
+      const hostBody = await hostsResponse.json();
+      hosts = Array.isArray(hostBody) ? hostBody : (hostBody.items || hostBody.hosts || []);
+      renderCatalog();
+      renderHosts();
+    } catch (error) {
+      const wrap = document.getElementById('security-mitigations-list');
+      if (wrap) wrap.innerHTML = `<div class="status-error">${esc(error.message || error)}</div>`;
+    }
+  }
+
+  document.getElementById('mitigation-hosts-select-all')?.addEventListener('click', () => {
+    hosts.forEach((host) => selectedHosts.add(String(host.agent_id || host.id || '')));
+    renderHosts();
+  });
+  document.getElementById('mitigation-hosts-select-none')?.addEventListener('click', () => {
+    selectedHosts.clear(); renderHosts();
+  });
+  document.getElementById('mitigation-assess')?.addEventListener('click', assess);
+  window.fleetSecurityMitigationsUi = { load };
+})();

--- a/server/app/templates/fleet-security-mitigations-ui.js
+++ b/server/app/templates/fleet-security-mitigations-ui.js
@@ -5,6 +5,8 @@
   let selectedMitigation = '';
   let hosts = [];
   const selectedHosts = new Set();
+  let lastAssessmentJobId = '';
+  const vulnerableHosts = new Set();
 
   const esc = (value) => String(value ?? '')
     .replaceAll('&', '&amp;').replaceAll('<', '&lt;').replaceAll('>', '&gt;')
@@ -66,14 +68,18 @@
   function renderResults(job) {
     const wrap = document.getElementById('mitigation-results');
     if (!wrap) return;
+    vulnerableHosts.clear();
     const rows = (job.runs || []).map((run) => {
       let result = {};
       try { result = JSON.parse(run.stdout_tail || run.stdout || '{}'); } catch (_) { result = {}; }
       const state = result.status || run.status;
-      const cls = state === 'mitigated' || state === 'not_applicable' ? 'status-ok' : (state === 'vulnerable' ? 'status-error' : 'status-muted');
+      if (state === 'vulnerable') vulnerableHosts.add(String(run.agent_id));
+      const cls = state === 'mitigated' || state === 'not_applicable' ? 'status-ok' : (state === 'vulnerable' ? 'status-error' : (state === 'reboot_required' ? 'status-warn' : 'status-muted'));
       return `<tr><td><code>${esc(run.agent_id)}</code></td><td class="${cls}">${esc(state)}</td><td>${esc(result.detail || run.error || '')}</td></tr>`;
     }).join('');
     wrap.innerHTML = `<table class="process-table"><thead><tr><th>Host</th><th>Assessment</th><th>Detail</th></tr></thead><tbody>${rows}</tbody></table>`;
+    const applyButton = document.getElementById('mitigation-apply');
+    if (applyButton) applyButton.disabled = !lastAssessmentJobId || vulnerableHosts.size === 0;
   }
 
   async function pollJob(jobId) {
@@ -107,12 +113,37 @@
       });
       const body = await response.json().catch(() => ({}));
       if (!response.ok) throw new Error(body.detail || `assessment failed (${response.status})`);
+      lastAssessmentJobId = body.job_id;
       await pollJob(body.job_id);
     } catch (error) {
       if (status) status.textContent = error.message || String(error);
       window.showToast?.(`Assessment failed: ${error.message || error}`, 'error');
     } finally {
       if (button) button.disabled = false;
+    }
+  }
+
+  async function requestApply() {
+    const status = document.getElementById('mitigation-status');
+    if (!lastAssessmentJobId || !vulnerableHosts.size) return;
+    if (!window.confirm(`Request approval to apply this mitigation to ${vulnerableHosts.size} vulnerable host(s)?`)) return;
+    const button = document.getElementById('mitigation-apply');
+    if (button) button.disabled = true;
+    try {
+      if (status) status.textContent = 'Creating approval request…';
+      const response = await fetch(`/security/mitigations/${encodeURIComponent(selectedMitigation)}/apply`, {
+        method: 'POST', credentials: 'include', headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ agent_ids: Array.from(vulnerableHosts), assessment_job_id: lastAssessmentJobId }),
+      });
+      const body = await response.json().catch(() => ({}));
+      if (!response.ok) throw new Error(body.detail || `apply request failed (${response.status})`);
+      if (status) status.textContent = `Approval request ${body.request_id} is pending.`;
+      window.showToast?.('Mitigation apply request sent for two-person approval', 'success');
+    } catch (error) {
+      if (status) status.textContent = error.message || String(error);
+      window.showToast?.(`Apply request failed: ${error.message || error}`, 'error');
+    } finally {
+      if (button) button.disabled = vulnerableHosts.size === 0;
     }
   }
 
@@ -143,5 +174,6 @@
     selectedHosts.clear(); renderHosts();
   });
   document.getElementById('mitigation-assess')?.addEventListener('click', assess);
+  document.getElementById('mitigation-apply')?.addEventListener('click', requestApply);
   window.fleetSecurityMitigationsUi = { load };
 })();

--- a/server/app/templates/index.html
+++ b/server/app/templates/index.html
@@ -1039,7 +1039,7 @@
     <div class="tab-content-custom" id="sshkeys-tab">
       <div class="admin-content">
         <div class="section-title">Security mitigations</div>
-        <div class="admin-note" style="margin-bottom:0.75rem;">Assess versioned, predefined security mitigations across selected hosts. Assessment is read-only; remediation is enabled separately only after its safety workflow is implemented.</div>
+        <div class="admin-note" style="margin-bottom:0.75rem;">Assess versioned, predefined security mitigations across selected hosts. Apply requires approval by a different administrator and is verified automatically on every host.</div>
 
         <div class="admin-card" style="margin-bottom:1rem;">
           <div class="admin-card-title">Mitigation catalog</div>
@@ -1053,6 +1053,7 @@
             <div id="mitigation-hosts-list" style="margin-top:0.75rem;max-height:240px;overflow:auto;border:1px solid var(--border);border-radius:10px;background:var(--panel-2);padding:0.5rem;"></div>
             <div style="margin-top:0.75rem;display:flex;gap:0.5rem;align-items:center;flex-wrap:wrap;">
               <button class="btn btn-primary" id="mitigation-assess" type="button">Assess selected hosts</button>
+              <button class="btn" id="mitigation-apply" type="button" disabled>Request apply to vulnerable hosts</button>
               <span id="mitigation-status" class="status-muted"></span>
             </div>
             <div id="mitigation-results" style="margin-top:0.75rem;"></div>

--- a/server/app/templates/index.html
+++ b/server/app/templates/index.html
@@ -1038,6 +1038,27 @@
 
     <div class="tab-content-custom" id="sshkeys-tab">
       <div class="admin-content">
+        <div class="section-title">Security mitigations</div>
+        <div class="admin-note" style="margin-bottom:0.75rem;">Assess versioned, predefined security mitigations across selected hosts. Assessment is read-only; remediation is enabled separately only after its safety workflow is implemented.</div>
+
+        <div class="admin-card" style="margin-bottom:1rem;">
+          <div class="admin-card-title">Mitigation catalog</div>
+          <div class="admin-card-body">
+            <div id="security-mitigations-list"><div class="status-muted">Loading…</div></div>
+            <div style="margin-top:0.75rem;display:flex;gap:0.5rem;flex-wrap:wrap;align-items:center;">
+              <button class="btn" id="mitigation-hosts-select-all" type="button">Select all hosts</button>
+              <button class="btn" id="mitigation-hosts-select-none" type="button">Select none</button>
+              <span class="status-muted">Selected: <span id="mitigation-hosts-count">0</span></span>
+            </div>
+            <div id="mitigation-hosts-list" style="margin-top:0.75rem;max-height:240px;overflow:auto;border:1px solid var(--border);border-radius:10px;background:var(--panel-2);padding:0.5rem;"></div>
+            <div style="margin-top:0.75rem;display:flex;gap:0.5rem;align-items:center;flex-wrap:wrap;">
+              <button class="btn btn-primary" id="mitigation-assess" type="button">Assess selected hosts</button>
+              <span id="mitigation-status" class="status-muted"></span>
+            </div>
+            <div id="mitigation-results" style="margin-top:0.75rem;"></div>
+          </div>
+        </div>
+
         <div class="section-title">SSH Keys</div>
         <div class="admin-note" style="margin-bottom:0.75rem;">Upload your public key and request deployment to hosts. An admin must approve. You can choose sudo mode: none, restricted, or full (admin-like).</div>
 
@@ -1779,6 +1800,7 @@
   <script src="/assets/fleet-reports-ui.js?v=__ASSET_VERSION__"></script>
   <script src="/assets/fleet-admin-ui.js?v=__ASSET_VERSION__"></script>
   <script src="/assets/fleet-failed-runs-ui.js?v=__ASSET_VERSION__"></script>
+  <script src="/assets/fleet-security-mitigations-ui.js?v=__ASSET_VERSION__"></script>
   <script src="/assets/fleet-app.js?v=__ASSET_VERSION__"></script>
 </body>
 

--- a/server/app/version.py
+++ b/server/app/version.py
@@ -1,1 +1,1 @@
-APP_VERSION = "0.0.21-alpha"
+APP_VERSION = "0.0.22-alpha"

--- a/server/app/version.py
+++ b/server/app/version.py
@@ -1,1 +1,1 @@
-APP_VERSION = "0.0.22-alpha"
+APP_VERSION = "0.0.23-alpha"

--- a/server/tests/frontend/page-shell-overflow.test.js
+++ b/server/tests/frontend/page-shell-overflow.test.js
@@ -12,6 +12,6 @@ describe('page shell release details', () => {
   });
 
   it('shows the next application version', () => {
-    expect(version).toContain('APP_VERSION = "0.0.21-alpha"');
+    expect(version).toContain('APP_VERSION = "0.0.22-alpha"');
   });
 });

--- a/server/tests/frontend/page-shell-overflow.test.js
+++ b/server/tests/frontend/page-shell-overflow.test.js
@@ -12,6 +12,6 @@ describe('page shell release details', () => {
   });
 
   it('shows the next application version', () => {
-    expect(version).toContain('APP_VERSION = "0.0.22-alpha"');
+    expect(version).toContain('APP_VERSION = "0.0.23-alpha"');
   });
 });

--- a/server/tests/frontend/security-mitigations-ui.test.js
+++ b/server/tests/frontend/security-mitigations-ui.test.js
@@ -8,13 +8,15 @@ describe('security mitigations UI', () => {
   const html = fs.readFileSync(path.join(root, 'server/app/templates/index.html'), 'utf8');
   const src = fs.readFileSync(path.join(root, 'server/app/templates/fleet-security-mitigations-ui.js'), 'utf8');
 
-  it('offers an assessment-only mitigation workflow in Security', () => {
+  it('offers assessment and approval-protected apply workflows in Security', () => {
     expect(html).toContain('id="security-mitigations-list"');
     expect(html).toContain('id="mitigation-hosts-list"');
     expect(html).toContain('id="mitigation-assess"');
     expect(html).toContain('/assets/fleet-security-mitigations-ui.js');
     expect(src).toContain('/security/mitigations');
     expect(src).toContain('/assess');
-    expect(src).not.toContain('/apply');
+    expect(html).toContain('id="mitigation-apply"');
+    expect(src).toContain('/apply');
+    expect(src).toContain('vulnerableHosts');
   });
 });

--- a/server/tests/frontend/security-mitigations-ui.test.js
+++ b/server/tests/frontend/security-mitigations-ui.test.js
@@ -1,0 +1,20 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const root = process.cwd();
+
+describe('security mitigations UI', () => {
+  const html = fs.readFileSync(path.join(root, 'server/app/templates/index.html'), 'utf8');
+  const src = fs.readFileSync(path.join(root, 'server/app/templates/fleet-security-mitigations-ui.js'), 'utf8');
+
+  it('offers an assessment-only mitigation workflow in Security', () => {
+    expect(html).toContain('id="security-mitigations-list"');
+    expect(html).toContain('id="mitigation-hosts-list"');
+    expect(html).toContain('id="mitigation-assess"');
+    expect(html).toContain('/assets/fleet-security-mitigations-ui.js');
+    expect(src).toContain('/security/mitigations');
+    expect(src).toContain('/assess');
+    expect(src).not.toContain('/apply');
+  });
+});

--- a/server/tests/test_security_mitigations_api.py
+++ b/server/tests/test_security_mitigations_api.py
@@ -1,0 +1,75 @@
+import importlib
+import sys
+
+
+def _reload_app_modules():
+    for key in list(sys.modules):
+        if key == "app" or key.startswith("app."):
+            sys.modules.pop(key, None)
+
+
+def test_rds_mitigation_catalog_and_assessment_job(monkeypatch):
+    for key, value in {
+        "DATABASE_URL": "sqlite+pysqlite:///:memory:",
+        "BOOTSTRAP_USERNAME": "admin",
+        "BOOTSTRAP_PASSWORD": "admin-password-123",
+        "UI_COOKIE_SECURE": "false",
+        "ALLOW_INSECURE_NO_AGENT_TOKEN": "true",
+        "AGENT_SHARED_TOKEN": "",
+        "DB_AUTO_CREATE_TABLES": "true",
+        "DB_REQUIRE_MIGRATIONS_UP_TO_DATE": "false",
+        "MFA_REQUIRE_FOR_PRIVILEGED": "false",
+        "CVE_SYNC_ENABLED": "false",
+        "METRICS_BACKGROUND_REFRESH_SECONDS": "0",
+    }.items():
+        monkeypatch.setenv(key, value)
+
+    _reload_app_modules()
+    app = importlib.import_module("app.app_factory").create_app()
+
+    from fastapi.testclient import TestClient
+    from app.db import SessionLocal
+    from app.models import AuditEvent
+    from sqlalchemy import select
+
+    with TestClient(app) as client:
+        registered = client.post("/agent/register", json={
+            "agent_id": "srv-mitigation", "hostname": "srv-mitigation",
+            "os_id": "ubuntu", "os_version": "24.04", "kernel": "test",
+            "labels": {"env": "test"},
+        })
+        assert registered.status_code == 200, registered.text
+
+        login = client.post("/auth/login", json={"username": "admin", "password": "admin-password-123"})
+        assert login.status_code == 200, login.text
+        csrf = client.cookies.get("fleet_csrf")
+        headers = {"X-CSRF-Token": csrf} if csrf else {}
+
+        catalog = client.get("/security/mitigations")
+        assert catalog.status_code == 200, catalog.text
+        mitigation = catalog.json()["items"][0]
+        assert mitigation["id"] == "linux-rds-disable"
+        assert mitigation["version"] == 1
+        assert mitigation["apply_available"] is False
+
+        unknown = client.post("/security/mitigations/not-real/assess", json={"agent_ids": ["srv-mitigation"]}, headers=headers)
+        assert unknown.status_code == 404
+
+        queued = client.post("/security/mitigations/linux-rds-disable/assess", json={"agent_ids": ["srv-mitigation"]}, headers=headers)
+        assert queued.status_code == 200, queued.text
+        job_id = queued.json()["job_id"]
+
+        claimed = client.get("/agent/next-job", params={"agent_id": "srv-mitigation"})
+        assert claimed.status_code == 200, claimed.text
+        job = claimed.json()["job"]
+        assert job["job_id"] == job_id
+        assert job["type"] == "security-mitigation"
+        assert job["mitigation_id"] == "linux-rds-disable"
+        assert job["mitigation_version"] == 1
+        assert job["action"] == "assess"
+
+        with SessionLocal() as db:
+            audit = db.execute(select(AuditEvent).where(AuditEvent.action == "security.mitigation.assessment.queued")).scalar_one()
+            assert audit.target_id == "linux-rds-disable"
+            assert audit.meta["mode"] == "ASSESS"
+            assert audit.meta["target_count"] == 1

--- a/server/tests/test_security_mitigations_api.py
+++ b/server/tests/test_security_mitigations_api.py
@@ -29,7 +29,7 @@ def test_rds_mitigation_catalog_and_assessment_job(monkeypatch):
 
     from fastapi.testclient import TestClient
     from app.db import SessionLocal
-    from app.models import AuditEvent
+    from app.models import AppUser, AuditEvent
     from sqlalchemy import select
 
     with TestClient(app) as client:
@@ -50,7 +50,8 @@ def test_rds_mitigation_catalog_and_assessment_job(monkeypatch):
         mitigation = catalog.json()["items"][0]
         assert mitigation["id"] == "linux-rds-disable"
         assert mitigation["version"] == 1
-        assert mitigation["apply_available"] is False
+        assert mitigation["apply_available"] is True
+        assert mitigation["approval_required"] is True
 
         unknown = client.post("/security/mitigations/not-real/assess", json={"agent_ids": ["srv-mitigation"]}, headers=headers)
         assert unknown.status_code == 404
@@ -67,6 +68,54 @@ def test_rds_mitigation_catalog_and_assessment_job(monkeypatch):
         assert job["mitigation_id"] == "linux-rds-disable"
         assert job["mitigation_version"] == 1
         assert job["action"] == "assess"
+
+        completed = client.post("/agent/job-event", json={
+            "agent_id": "srv-mitigation", "job_id": job_id, "job_nonce": job["job_nonce"],
+            "status": "success", "exit_code": 0,
+            "stdout": '{"status":"vulnerable","detail":"rds can be loaded"}',
+        })
+        assert completed.status_code == 200, completed.text
+
+        apply_request = client.post(
+            "/security/mitigations/linux-rds-disable/apply",
+            json={"agent_ids": ["srv-mitigation"], "assessment_job_id": job_id},
+            headers=headers,
+        )
+        assert apply_request.status_code == 200, apply_request.text
+        assert apply_request.json()["approval_required"] is True
+        request_id = apply_request.json()["request_id"]
+
+        pending = client.get("/approvals/admin/pending")
+        assert pending.status_code == 200, pending.text
+        approval = next(item for item in pending.json()["items"] if item["id"] == request_id)
+        assert approval["action"] == "security-mitigation-apply"
+        assert approval["payload"]["assessment_job_id"] == job_id
+
+        with SessionLocal() as db:
+            from app.routers.auth import pwd_context
+            db.add(AppUser(
+                username="second-admin", password_hash=pwd_context.hash("second-admin-password-123"),
+                role="admin", is_active=True,
+            ))
+            db.commit()
+
+        with TestClient(app) as approver:
+            second_login = approver.post("/auth/login", json={
+                "username": "second-admin", "password": "second-admin-password-123",
+            })
+            assert second_login.status_code == 200, second_login.text
+            second_csrf = approver.cookies.get("fleet_csrf")
+            second_headers = {"X-CSRF-Token": second_csrf} if second_csrf else {}
+            approved = approver.post(f"/approvals/admin/{request_id}/approve", headers=second_headers)
+            assert approved.status_code == 200, approved.text
+            assert approved.json()["status"] == "executed"
+            apply_job_id = approved.json()["execution_ref"]
+
+        apply_claim = client.get("/agent/next-job", params={"agent_id": "srv-mitigation"})
+        assert apply_claim.status_code == 200, apply_claim.text
+        apply_job = apply_claim.json()["job"]
+        assert apply_job["job_id"] == apply_job_id
+        assert apply_job["action"] == "apply"
 
         with SessionLocal() as db:
             audit = db.execute(select(AuditEvent).where(AuditEvent.action == "security.mitigation.assessment.queued")).scalar_one()


### PR DESCRIPTION
## Summary
- add read-only RDS security mitigation assessments
- add approval-gated mitigation remediation
- expose mitigation controls in the UI and agent
- update the release version and matching frontend test

## Validation
- `go test ./cmd/fleet-agent`
- `npm run test:frontend` (32 files, 82 tests)
- `git diff --check`

## Note
- Python API test was not run locally because the existing virtual environment does not contain pytest.